### PR TITLE
Fix printing skb of the first event.

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -65,10 +65,8 @@ func (o *output) Print(event *Event) {
 
 	if o.flags.OutputSkb {
 		id := uint32(event.PrintSkbId)
-		if event.PrintSkbId != 0 {
-			if str, err := o.printSkbMap.LookupBytes(&id); err == nil {
-				fmt.Printf("\n%s", string(str))
-			}
+		if str, err := o.printSkbMap.LookupBytes(&id); err == nil {
+			fmt.Printf("\n%s", string(str))
 		}
 	}
 


### PR DESCRIPTION
The initial value of print_skb_id is set to 0. Combined with the fetch
and add, the first event always gets id=0 (also, the one which overflows
u8).

Previously, the outputter was assuming that id=0 means that no str for
printing the skb was allocated which led to the first event not printing
the skb.

Signed-off-by: Martynas Pumputis <m@lambda.lt>