### PR TITLE
Use log instead of fmt for printing info

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -142,7 +141,7 @@ func main() {
 		}
 	}
 	bar.Finish()
-	fmt.Printf("Attached (ignored %d)\n", ignored)
+	log.Printf("Attached (ignored %d)\n", ignored)
 
 	rd, err := perf.NewReader(events, os.Getpagesize())
 	if err != nil {


### PR DESCRIPTION
Redirecting input for further processing becomes cleaner once info is
printed on stderr instead of stdout

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
