### PR TITLE
[RFC] Print container metadata from an external map

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -49,6 +49,7 @@ struct event_t {
 	struct skb_meta meta;
 	struct tuple tuple;
 	s64 print_stack_id;
+	u64 mntns;
 } __attribute__((packed));
 
 struct {
@@ -294,6 +295,9 @@ handle_everything(struct sk_buff *skb, struct pt_regs *ctx) {
 	event.addr = PT_REGS_IP(ctx);
 	event.skb_addr = (u64) skb;
 	event.ts = bpf_ktime_get_ns();
+        struct task_struct *current_task;
+        current_task = (struct task_struct *)bpf_get_current_task();
+	event.mntns = BPF_CORE_READ(current_task, nsproxy, mnt_ns, ns.inum);
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
 
 	return 0;

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -24,6 +24,8 @@ type Flags struct {
 	OutputTuple      bool
 	OutputSkb        bool
 	OutputStack      bool
+
+	OutputMountNamespaceMetadata string
 }
 
 func (f *Flags) SetFlags() {
@@ -39,6 +41,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputTuple, "output-tuple", false, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
+	flag.StringVar(&f.OutputMountNamespaceMetadata, "mount-namespace-metadata", "", "print additional metadata from this map indexed by mount namespace")
 }
 
 type Tuple struct {
@@ -73,4 +76,5 @@ type Event struct {
 	Meta         Meta
 	Tuple        Tuple
 	PrintStackId int64
+	Mntns        uint64
 }

--- a/vendor/github.com/cilium/ebpf/pkg/btf/btf.go
+++ b/vendor/github.com/cilium/ebpf/pkg/btf/btf.go
@@ -587,6 +587,15 @@ func HandleSpec(s *Handle) (*Spec, error) {
 	return info.BTF, nil
 }
 
+func SpecFromFD(fd uint32) (*Spec, error) {
+	info, err := newInfoFromFd(pkg.NewFD(fd))
+	if err != nil {
+		return nil, fmt.Errorf("get BTF spec for handle: %w", err)
+	}
+
+	return info.BTF, nil
+}
+
 // Close destroys the handle.
 //
 // Subsequent calls to FD will return an invalid value.


### PR DESCRIPTION
Inspektor Gadget adds the following map about Kubernetes containers (https://github.com/kinvolk/inspektor-gadget/pull/353). The keys are the mount namespace ids.
```
$ sudo bpftool map dump pinned /sys/fs/bpf/gadget/containers
[{
        "key": 4026533313,
        "value": {
            "container_id": "f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c",
            "namespace": "default",
            "pod": "shell",
            "container": "shell"
        }
    },{
        "key": 4026533175,
        "value": {
            "container_id": "611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473",
            "namespace": "default",
            "pod": "nginx",
            "container": "nginx"
        }
    },...
```

This patch enables pwru to use this map without hardcoding the fields to print. The fields are discovered via BTF.
```
$ sudo ./pwru --filter-dst-ip 172.18.0.3 --mount-namespace-metadata /sys/fs/bpf/gadget/containers
               SKB         PROCESS                     FUNC        TIMESTAMP
0xffff9c2e4c1730e0          [wget]             ip_local_out  182893007811626
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]           __ip_local_out  182893007838180
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]             nf_hook_slow  182893007844685
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]      selinux_ipv4_output  182893007851298
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]                ip_output  182893007857753
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]             nf_hook_slow  182893007863014
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]   selinux_ipv4_postroute  182893007869697
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget]     selinux_ip_postroute  182893007875452
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0          [wget] selinux_ip_postroute_compat  182893007880619
container_id=f3a382e699cf89aff859d2b9a99b94813628a01add4c70d95347dc20498d9f1c namespace=default pod=shell container=shell
0xffff9c2e4c1730e0         [nginx]              __kfree_skb  182893009748484
container_id=611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473 namespace=default pod=nginx container=nginx
0xffff9c2e4c1730e0         [nginx]   skb_release_head_state  182893009758061
container_id=611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473 namespace=default pod=nginx container=nginx
0xffff9c2e4c1730e0         [nginx]               sock_rfree  182893009763858
container_id=611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473 namespace=default pod=nginx container=nginx
0xffff9c2e4c1730e0         [nginx]         skb_release_data  182893009768616
container_id=611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473 namespace=default pod=nginx container=nginx
0xffff9c2e4c1730e0         [nginx]             kfree_skbmem  182893009774774
container_id=611ac0d5f57fa076175770efcf35ebde805a2167938730f0282299c324558473 namespace=default pod=nginx container=nginx
```

To test this, I used the following commands:
```
$ kubectl run --image nginx nginx
$ kubectl get pod nginx -o jsonpath='{.status.podIP}'
172.18.0.3
$ kubectl run -ti --rm --image=busybox shell
/ # wget 172.18.0.3
```

TODO:
- [ ] Changes to cilium/ebpf to be prepared upstream. See also https://github.com/cilium/pwru/issues/8
- [ ] The current patch assumes that there is only one struct in the BTF types and assumes it only contains strings.
- [ ] How to print the data on a single line?