### PR TITLE
add option --output-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ Usage of ./pwru:
       --filter-dst-port uint16      filter destination port
       --filter-func string          filter the kernel functions that can be probed; the filter can be a regular expression (RE2)
       --filter-mark uint32          filter skb mark
+      --filter-netns uint32         filter netns inode
       --filter-proto string         filter L4 protocol (tcp, udp, icmp)
       --filter-src-ip string        filter source IP addr
       --filter-src-port uint16      filter source port
+      --output-limit-lines uint     exit the program after the number of events has been received/printed
       --output-meta                 print skb metadata
       --output-relative-timestamp   print relative timestamp per skb
       --output-skb                  print skb

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -27,6 +27,7 @@ type Flags struct {
 	OutputTuple      bool
 	OutputSkb        bool
 	OutputStack      bool
+	OutputLimitLines uint64
 }
 
 func (f *Flags) SetFlags() {
@@ -43,6 +44,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputTuple, "output-tuple", false, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
+	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
 }
 
 type Tuple struct {


### PR DESCRIPTION
1. Limit the number of printing to prevent running program from unstopping.
   The default number is 1000. The number 0 is for nearly unlimited printing.
2. update README.md

Signed-off-by: Leon Huayra <hffilwlqm@gmail.com>