### PR TITLE
bpf/headers: add script to update headers from libbpf

### DIFF
--- a/bpf/headers/bpf_helper_defs.h
+++ b/bpf/headers/bpf_helper_defs.h
@@ -36,6 +36,7 @@ struct btf_ptr;
 struct inode;
 struct socket;
 struct file;
+struct bpf_timer;
 
 /*
  * bpf_map_lookup_elem
@@ -2094,7 +2095,7 @@ static void *(*bpf_get_local_storage)(void *map, __u64 flags) = (void *) 81;
  * bpf_sk_select_reuseport
  *
  * 	Select a **SO_REUSEPORT** socket from a
- * 	**BPF_MAP_TYPE_REUSEPORT_ARRAY** *map*.
+ * 	**BPF_MAP_TYPE_REUSEPORT_SOCKARRAY** *map*.
  * 	It checks the selected socket is matching the incoming
  * 	request in the socket buffer.
  *
@@ -3922,5 +3923,124 @@ static long (*bpf_btf_find_by_name_kind)(char *name, int name_sz, __u32 kind, in
  * 	A syscall result.
  */
 static long (*bpf_sys_close)(__u32 fd) = (void *) 168;
+
+/*
+ * bpf_timer_init
+ *
+ * 	Initialize the timer.
+ * 	First 4 bits of *flags* specify clockid.
+ * 	Only CLOCK_MONOTONIC, CLOCK_REALTIME, CLOCK_BOOTTIME are allowed.
+ * 	All other bits of *flags* are reserved.
+ * 	The verifier will reject the program if *timer* is not from
+ * 	the same *map*.
+ *
+ * Returns
+ * 	0 on success.
+ * 	**-EBUSY** if *timer* is already initialized.
+ * 	**-EINVAL** if invalid *flags* are passed.
+ * 	**-EPERM** if *timer* is in a map that doesn't have any user references.
+ * 	The user space should either hold a file descriptor to a map with timers
+ * 	or pin such map in bpffs. When map is unpinned or file descriptor is
+ * 	closed all timers in the map will be cancelled and freed.
+ */
+static long (*bpf_timer_init)(struct bpf_timer *timer, void *map, __u64 flags) = (void *) 169;
+
+/*
+ * bpf_timer_set_callback
+ *
+ * 	Configure the timer to call *callback_fn* static function.
+ *
+ * Returns
+ * 	0 on success.
+ * 	**-EINVAL** if *timer* was not initialized with bpf_timer_init() earlier.
+ * 	**-EPERM** if *timer* is in a map that doesn't have any user references.
+ * 	The user space should either hold a file descriptor to a map with timers
+ * 	or pin such map in bpffs. When map is unpinned or file descriptor is
+ * 	closed all timers in the map will be cancelled and freed.
+ */
+static long (*bpf_timer_set_callback)(struct bpf_timer *timer, void *callback_fn) = (void *) 170;
+
+/*
+ * bpf_timer_start
+ *
+ * 	Set timer expiration N nanoseconds from the current time. The
+ * 	configured callback will be invoked in soft irq context on some cpu
+ * 	and will not repeat unless another bpf_timer_start() is made.
+ * 	In such case the next invocation can migrate to a different cpu.
+ * 	Since struct bpf_timer is a field inside map element the map
+ * 	owns the timer. The bpf_timer_set_callback() will increment refcnt
+ * 	of BPF program to make sure that callback_fn code stays valid.
+ * 	When user space reference to a map reaches zero all timers
+ * 	in a map are cancelled and corresponding program's refcnts are
+ * 	decremented. This is done to make sure that Ctrl-C of a user
+ * 	process doesn't leave any timers running. If map is pinned in
+ * 	bpffs the callback_fn can re-arm itself indefinitely.
+ * 	bpf_map_update/delete_elem() helpers and user space sys_bpf commands
+ * 	cancel and free the timer in the given map element.
+ * 	The map can contain timers that invoke callback_fn-s from different
+ * 	programs. The same callback_fn can serve different timers from
+ * 	different maps if key/value layout matches across maps.
+ * 	Every bpf_timer_set_callback() can have different callback_fn.
+ *
+ *
+ * Returns
+ * 	0 on success.
+ * 	**-EINVAL** if *timer* was not initialized with bpf_timer_init() earlier
+ * 	or invalid *flags* are passed.
+ */
+static long (*bpf_timer_start)(struct bpf_timer *timer, __u64 nsecs, __u64 flags) = (void *) 171;
+
+/*
+ * bpf_timer_cancel
+ *
+ * 	Cancel the timer and wait for callback_fn to finish if it was running.
+ *
+ * Returns
+ * 	0 if the timer was not active.
+ * 	1 if the timer was active.
+ * 	**-EINVAL** if *timer* was not initialized with bpf_timer_init() earlier.
+ * 	**-EDEADLK** if callback_fn tried to call bpf_timer_cancel() on its
+ * 	own timer which would have led to a deadlock otherwise.
+ */
+static long (*bpf_timer_cancel)(struct bpf_timer *timer) = (void *) 172;
+
+/*
+ * bpf_get_func_ip
+ *
+ * 	Get address of the traced function (for tracing and kprobe programs).
+ *
+ * Returns
+ * 	Address of the traced function.
+ */
+static __u64 (*bpf_get_func_ip)(void *ctx) = (void *) 173;
+
+/*
+ * bpf_get_attach_cookie
+ *
+ * 	Get bpf_cookie value provided (optionally) during the program
+ * 	attachment. It might be different for each individual
+ * 	attachment, even if BPF program itself is the same.
+ * 	Expects BPF program context *ctx* as a first argument.
+ *
+ * 	Supported for the following program types:
+ * 		- kprobe/uprobe;
+ * 		- tracepoint;
+ * 		- perf_event.
+ *
+ * Returns
+ * 	Value specified by user at BPF link creation/attachment time
+ * 	or 0, if it was not specified.
+ */
+static __u64 (*bpf_get_attach_cookie)(void *ctx) = (void *) 174;
+
+/*
+ * bpf_task_pt_regs
+ *
+ * 	Get the struct pt_regs associated with **task**.
+ *
+ * Returns
+ * 	A pointer to struct pt_regs.
+ */
+static long (*bpf_task_pt_regs)(struct task_struct *task) = (void *) 175;
 
 

--- a/bpf/headers/update.sh
+++ b/bpf/headers/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Version of libbpf to fetch headers from
+LIBBPF_VERSION=0.5.0
+
+# The headers we want
+prefix=libbpf-"$LIBBPF_VERSION"
+headers=(
+    "$prefix"/src/bpf_core_read.h
+    "$prefix"/src/bpf_helper_defs.h
+    "$prefix"/src/bpf_helpers.h
+)
+
+# Fetch libbpf release and extract the desired headers
+curl -sL "https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz" | \
+    tar -xz --xform='s#.*/##' "${headers[@]}"


### PR DESCRIPTION
Add an update.sh script which can be used to update the libbpf headers
used by pwru. Pin it to libbpf 0.5.0 which seems to be the closest
matching version. Updating to that version leads to some benign changes
to bpf_helper_defs.h.

This is based on the script in github.com/cilium/ebpf.