### PR TITLE
internal/pwru: Match entire string for --filter-func

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ the eBPF bytecode from the [release page](https://github.com/cilium/pwru/release
 Usage of ./pwru:
       --filter-dst-ip string        filter destination IP addr
       --filter-dst-port uint16      filter destination port
-      --filter-func string          filter the kernel functions that can be probed; the filter can be a regular expression (RE2)
+      --filter-func string          filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
       --filter-mark uint32          filter skb mark
       --filter-netns uint32         filter netns inode
       --filter-proto string         filter L4 protocol (tcp, udp, icmp)
@@ -112,6 +112,10 @@ Usage of ./pwru:
 
 If multiple filters are specified, all of them have to match in order for a
 packet to be traced.
+
+The `--filter-func` switch does an exact match on function names i.e.
+`--filter-func=foo` only matches `foo()`; for a wildcarded match, try
+`--filter-func=".*foo.*"` instead.
 
 ## Developing
 

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -31,7 +31,7 @@ type Flags struct {
 }
 
 func (f *Flags) SetFlags() {
-	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter the kernel functions that can be probed; the filter can be a regular expression (RE2)")
+	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
 	flag.StringVar(&f.FilterProto, "filter-proto", "", "filter L4 protocol (tcp, udp, icmp, icmp6)")
 	flag.StringVar(&f.FilterSrcIP, "filter-src-ip", "", "filter source IP addr")
 	flag.StringVar(&f.FilterDstIP, "filter-dst-ip", "", "filter destination IP addr")

--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -26,8 +26,9 @@ func GetFuncs(pattern string) (Funcs, error) {
 	}
 	callback := func(typ btf.Type) {
 		fn := typ.(*btf.Func)
+		fnName := string(fn.Name)
 
-		if pattern != "" && !reg.Match([]byte(fn.Name)) {
+		if pattern != "" && reg.FindString(fnName) != fnName {
 			return
 		}
 
@@ -37,7 +38,7 @@ func GetFuncs(pattern string) (Funcs, error) {
 			if ptr, ok := p.Type.(*btf.Pointer); ok {
 				if strct, ok := ptr.Target.(*btf.Struct); ok {
 					if strct.Name == "sk_buff" && i <= 5 {
-						funcs[string(fn.Name)] = i
+						funcs[fnName] = i
 						return
 					}
 				}


### PR DESCRIPTION
Hi all,

Currently `--filter-func=kfree_skb` matches all functions whose name
contains the `"kfree_skb"` string, including `__kfree_skb()`, `kfree_skbmem()`
etc.  To match `kfree_skb()` only, one has to do something like
`--filter-func="^kfree_skb$"`.

This is counterintuitive.  Match the entire string instead in
`GetFuncs()`, so that `--filter-func=kfree_skb` only matches `kfree_skb()`.
To match all function names containing `"kfree_skb"`, one should do
something like `--filter-func=".*kfree_skb.*"` instead.

Thanks,
Signed-off-by: Peilin Ye <peilin.ye@bytedance.com>