### PR TITLE
Revert "support output cpu"

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -49,7 +49,6 @@ struct event_t {
 	u64 addr;
 	u64 skb_addr;
 	u64 ts;
-	u32 cpu;
 	typeof(print_skb_id) print_skb_id;
 	struct skb_meta meta;
 	struct tuple tuple;
@@ -374,7 +373,6 @@ handle_everything(struct sk_buff *skb, struct pt_regs *ctx) {
 	event.addr = PT_REGS_IP(ctx);
 	event.skb_addr = (u64) skb;
 	event.ts = bpf_ktime_get_ns();
-	event.cpu = bpf_get_smp_processor_id();
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
 
 	return 0;

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -34,7 +34,7 @@ func NewOutput(flags *Flags, printSkbMap *ebpf.Map, printStackMap *ebpf.Map, add
 }
 
 func (o *output) PrintHeader() {
-	fmt.Printf("%18s %16s %24s %8s %16s\n", "SKB", "PROCESS", "FUNC", "CPU", "TIMESTAMP")
+	fmt.Printf("%18s %16s %24s %16s\n", "SKB", "PROCESS", "FUNC", "TIMESTAMP")
 }
 
 func (o *output) Print(event *Event) {
@@ -65,7 +65,7 @@ func (o *output) Print(event *Event) {
 	} else {
 		funcName = fmt.Sprintf("0x%x", addr)
 	}
-	fmt.Printf("%18s %16s %24s %8d %16d", fmt.Sprintf("0x%x", event.SAddr), fmt.Sprintf("[%s]", execName), funcName, event.CPU, ts)
+	fmt.Printf("%18s %16s %24s %16d", fmt.Sprintf("0x%x", event.SAddr), fmt.Sprintf("[%s]", execName), funcName, ts)
 	o.lastSeenSkb[event.SAddr] = event.Timestamp
 
 	if o.flags.OutputMeta {

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -80,7 +80,6 @@ type Event struct {
 	Addr         uint64
 	SAddr        uint64
 	Timestamp    uint64
-	CPU          uint32
 	PrintSkbId   uint64
 	Meta         Meta
 	Tuple        Tuple


### PR DESCRIPTION
This reverts commit 015a7340a3020963ba0cee4c313655198fb30f6c.

On the 5.16.1-arch1-1 kernel this commit caused the following verifier
error when running "pwru --filter-dst-ip 8.8.8.8 --output-skb":

    2022/01/25 12:02:40 Loading objects: field KprobeSkb1:
    program kprobe_skb_1: load program: permission denied:
    R1 type=ctx expected=fp
    ; int kprobe_skb_1(struct pt_regs *ctx) {
    0: (bf) r9 = r1
    ; struct sk_buff *skb = (struct sk_buff *) PT_REGS_PARM1(ctx);
    1: (79) r8 = *(u64 *)(r9 +112)
    2: (b7) r1 = 0
    ; struct event_t event = {};
    3: (63) *(u32 *)(r10 -56) = r1
    last_idx 3 first_idx 0

The full log is included in the revert PR.

cc @Asphaltt 

[verifier.log](https://github.com/cilium/pwru/files/7934153/verifier.log)