### PR TITLE
Add argument per-cpu-buffer and fix Vagrant setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt -y update
 RUN apt install -y llvm-12 clang-12
 RUN ln -s /usr/bin/clang-12 /usr/bin/clang
+RUN ln -s /usr/lib/llvm-12/bin/llvm-strip /usr/local/bin/llvm-strip
 WORKDIR /pwru
 COPY . .
 RUN make

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,5 +8,7 @@ Vagrant.configure("2") do |config|
       apt-get update
       apt-get install -y clang-12 golang make
       update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
+      [ -f /usr/lib/llvm-12/bin/llvm-strip ] && [ -f /usr/local/bin/llvm-strip ] || \
+      ln -s /usr/lib/llvm-12/bin/llvm-strip /usr/local/bin/llvm-strip
     SHELL
 end

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -30,6 +30,8 @@ type Flags struct {
 	OutputSkb        bool
 	OutputStack      bool
 	OutputLimitLines uint64
+
+	PerCPUBuffer	uint32
 }
 
 func (f *Flags) SetFlags() {
@@ -48,6 +50,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
+	flag.Uint32Var(&f.PerCPUBuffer, "per-cpu-buffer", 0, "per CPU buffer in bytes")
 }
 
 type Tuple struct {

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -6,6 +6,7 @@ package pwru
 
 import (
 	flag "github.com/spf13/pflag"
+	"os"
 )
 
 const (
@@ -31,7 +32,7 @@ type Flags struct {
 	OutputStack      bool
 	OutputLimitLines uint64
 
-	PerCPUBuffer	uint32
+	PerCPUBuffer	int
 }
 
 func (f *Flags) SetFlags() {
@@ -50,7 +51,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
-	flag.Uint32Var(&f.PerCPUBuffer, "per-cpu-buffer", 0, "per CPU buffer in bytes")
+	flag.IntVar(&f.PerCPUBuffer, "per-cpu-buffer", os.Getpagesize(), "per CPU buffer in bytes")
 }
 
 type Tuple struct {

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ func main() {
 	var (
 		kprobe1, kprobe2, kprobe3, kprobe4, kprobe5 *ebpf.Program
 		cfgMap, events, printSkbMap, printStackMap  *ebpf.Map
-		// Size of the per CPU buffer in bytes
-		perCPUBuffer int
 	)
 
 	flags := pwru.Flags{}
@@ -101,13 +99,7 @@ func main() {
 		printStackMap = objs.PrintStackMap
 	}
 
-	if flags.PerCPUBuffer == 0 {
-		perCPUBuffer = os.Getpagesize()
-	} else {
-		perCPUBuffer = int(flags.PerCPUBuffer)
-	}
-
-	log.Printf("Per cpu buffer size: %d bytes\n", perCPUBuffer)
+	log.Printf("Per cpu buffer size: %d bytes\n", flags.PerCPUBuffer)
 	pwru.ConfigBPFMap(&flags, cfgMap)
 
 	log.Println("Attaching kprobes...")
@@ -151,7 +143,7 @@ func main() {
 	bar.Finish()
 	log.Printf("Attached (ignored %d)\n", ignored)
 
-	rd, err := perf.NewReader(events, perCPUBuffer)
+	rd, err := perf.NewReader(events, flags.PerCPUBuffer)
 	if err != nil {
 		log.Fatalf("Creating perf event reader: %s", err)
 	}


### PR DESCRIPTION
Following up on this comment https://github.com/cilium/pwru/issues/46#issuecomment-1023213310 adding a new command line argument to set the per CPU buffer. Fixed an issue in the Vagrant setup where llvm-strip is not in $PATH and make fails.