### PR TITLE
go.mod, vendor: update github.com/cilium/ebpf to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/cheggaaa/pb/v3 v3.0.8
-	github.com/cilium/ebpf v0.8.2-0.20220523131249-951bb28908d2
+	github.com/cilium/ebpf v0.9.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/cheggaaa/pb/v3 v3.0.8 h1:bC8oemdChbke2FHIIGy9mn4DPJ2caZYQnfbRqwmdCoA=
 github.com/cheggaaa/pb/v3 v3.0.8/go.mod h1:UICbiLec/XO6Hw6k+BHEtHeQFzzBH4i2/qk/ow1EJTA=
-github.com/cilium/ebpf v0.8.2-0.20220523131249-951bb28908d2 h1:hBJepqtelUY3L6uH5Slv3luaQHWs8pybShH0wQi/eQw=
-github.com/cilium/ebpf v0.8.2-0.20220523131249-951bb28908d2/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
+github.com/cilium/ebpf v0.9.0 h1:ldiV+FscPCQ/p3mNEV4O02EPbUZJFsoEtHvIr9xLTvk=
+github.com/cilium/ebpf v0.9.0/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,7 +5,7 @@ github.com/VividCortex/ewma
 ## explicit; go 1.12
 github.com/cheggaaa/pb/v3
 github.com/cheggaaa/pb/v3/termutil
-# github.com/cilium/ebpf v0.8.2-0.20220523131249-951bb28908d2
+# github.com/cilium/ebpf v0.9.0
 ## explicit; go 1.17
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
Release notes: https://github.com/cilium/ebpf/releases/tag/v0.9.0