### PR TITLE
Fix again min kernel vsn in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ above example with the following commands.
 
 ### Requirements
 
-`pwru` requires >= 5.5 kernel to run. For `--output-skb` >= 5.9 kernel is required.
+`pwru` requires >= 5.3 kernel to run. For `--output-skb` >= 5.9 kernel is required.
 
 The following kernel configuration is required.
 


### PR DESCRIPTION
We came to early to a conclusion regarding >= 5.5 min kernel. The tool works on 5.3 too. See https://github.com/cilium/pwru/issues/21#issuecomment-1160206797.