### PR TITLE
Silence clang build warnings and fix Makefile release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release:
 		--rm \
 		--workdir /pwru \
 		--volume `pwd`:/pwru docker.io/library/golang:1.18.2-alpine3.15 \
-		sh -c "apk add --no-cache make git clang && git config --global --add safe.directory /cilium && make local-release VERSION=${VERSION}"
+		sh -c "apk add --no-cache make git clang llvm && git config --global --add safe.directory /cilium && make local-release VERSION=${VERSION}"
 
 local-release: clean
 	OS=linux; \

--- a/main_amd64.go
+++ b/main_amd64.go
@@ -2,7 +2,7 @@
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for amd64"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -D__TARGET_ARCH_x86 -I./bpf/headers
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D__TARGET_ARCH_x86 -I./bpf/headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -D__TARGET_ARCH_x86 -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D__TARGET_ARCH_x86 -I./bpf/headers -Wno-address-of-packed-member
 
 package main

--- a/main_arm64.go
+++ b/main_arm64.go
@@ -2,7 +2,7 @@
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for arm64"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -D__TARGET_ARCH_arm64 -I./bpf/headers
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D__TARGET_ARCH_arm64 -I./bpf/headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -D__TARGET_ARCH_arm64 -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D__TARGET_ARCH_arm64 -I./bpf/headers -Wno-address-of-packed-member
 
 package main


### PR DESCRIPTION
1. Running either `make release` or `make local-release` will cause clang to emit warning messages of type `-Waddress-of-packed-member`. Silence the warnings by explicitly ignoring it.

2. Running `make release` will get error message like `Error: exec: "llvm-strip": executable file not found in $PATH`, fixed by installing `llvm`.

