### PR TITLE
Run release build as regular user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vagrant
 pwru
+release
 tags
 kprobepwru_bpf*
 kprobepwruwithoutoutputskb_bpf*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 RUN apt update -y -q
 RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -q curl build-essential ca-certificates
-RUN curl -s https://storage.googleapis.com/golang/go1.18.2.linux-amd64.tar.gz| tar -v -C /usr/local -xz
+RUN curl -s https://storage.googleapis.com/golang/go1.18.3.linux-amd64.tar.gz| tar -v -C /usr/local -xz
 ENV PATH $PATH:/usr/local/go/bin
 RUN apt install -y wget gnupg2
 RUN printf "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main" | tee /etc/apt/sources.list.d/llvm-toolchain-xenial-12.list

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ release:
 		--env "RELEASE_GID=$(RELEASE_GID)" \
 		--rm \
 		--workdir /pwru \
-		--volume `pwd`:/pwru docker.io/library/golang:1.18.2-alpine3.15 \
+		--volume `pwd`:/pwru docker.io/library/golang:1.18.3-alpine3.16 \
 		sh -c "apk add --no-cache make git clang llvm && git config --global --add safe.directory /cilium && make local-release VERSION=${VERSION}"
 
 local-release: clean


### PR DESCRIPTION
Follow the approach taken in cilium/hubble and cilium/cilium-cli `make release` targets, see cilium/hubble#751 and cilium/cilium-cli#945.

Also update Go and alpine to the most recent versions and add the `release/` directory to `.gitignore`.