### PR TITLE
Run with specified kernel BTF file

### DIFF
--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -5,8 +5,9 @@
 package pwru
 
 import (
-	flag "github.com/spf13/pflag"
 	"os"
+
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -15,6 +16,8 @@ const (
 
 type Flags struct {
 	ShowVersion bool
+
+	KernelBTF string
 
 	FilterNetns   uint32
 	FilterMark    uint32
@@ -32,11 +35,12 @@ type Flags struct {
 	OutputStack      bool
 	OutputLimitLines uint64
 
-	PerCPUBuffer	int
+	PerCPUBuffer int
 }
 
 func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.ShowVersion, "version", false, "show pwru version and exit")
+	flag.StringVar(&f.KernelBTF, "kernel-btf", "", "specify kernel BTF file")
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
 	flag.StringVar(&f.FilterProto, "filter-proto", "", "filter L4 protocol (tcp, udp, icmp, icmp6)")
 	flag.StringVar(&f.FilterSrcIP, "filter-src-ip", "", "filter source IP addr")

--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -13,13 +13,8 @@ import (
 
 type Funcs map[string]int
 
-func GetFuncs(pattern string) (Funcs, error) {
+func GetFuncs(pattern string, spec *btf.Spec) (Funcs, error) {
 	funcs := Funcs{}
-
-	spec, err := btf.LoadKernelSpec()
-	if err != nil {
-		return nil, err
-	}
 
 	reg, err := regexp.Compile(pattern)
 	if err != nil {


### PR DESCRIPTION
`pwru` can not runs in the Linux server, whose kernel is built without
`CONFIG_DEBUG_INFO_BTF=y`. But `pwru` can runs with specified kernel BTF
file in such Linux server.

I tried to run `pwru` on Ubuntu 20.04, whose kernel is 5.4 and is built
without `CONFIG_DEBUG_INFO_BTF=y`. Then, I downloaded the kernel BTF
file from github.com/aquasecurity/btfhub, and ran `pwru` with
`--kernel-btf`.

Unfortunately, I waited minutes to exit `pwru`. So I add a progress bar
when exit.

- add option `--kernel-btf`
- print a progress bar while detaching kprobes

Signed-off-by: Leon Hwang <hffilwlqm@gmail.com>