### PR TITLE
Try to fix endbr64 kprobe mess

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -63,6 +63,11 @@ func (o *output) Print(event *Event) {
 	var funcName string
 	if ksym, ok := o.addr2name.Addr2NameMap[addr]; ok {
 		funcName = ksym.name
+	} else if ksym, ok := o.addr2name.Addr2NameMap[addr-4]; runtime.GOARCH == "amd64" && ok {
+		// Assume that function has ENDBR in its prelude (enabled by CONFIG_X86_KERNEL_IBT).
+		// See https://lore.kernel.org/bpf/20220811091526.172610-5-jolsa@kernel.org/
+		// for more ctx.
+		funcName = ksym.name
 	} else {
 		funcName = fmt.Sprintf("0x%x", addr)
 	}


### PR DESCRIPTION
On 5.18+ when CONFIG_X86_KERNEL_IBT is set *some* functions gets endbr64 instruction (size 4 bytes) which screws up the kprobe addressing \[1\].

Assume that if no kallsym is found, then it's due to the endbr64.

Tested locally:

    $ iptables -t filter -I OUTPUT 1 -m tcp --proto tcp \
                --dst 1.1.1.1/32 -j DROP
    $ pwru --filter-dst-ip=1.1.1.1 --output-tuple > foo&
    $ curl 1.1.1.1
    $ cat foo
	PROCESS                     FUNC
	 [curl]             ip_local_out
	 [curl]           __ip_local_out
	 [curl]             nf_hook_slow
	 [curl]         kfree_skb_reason
	 [curl]   skb_release_head_state
	 [curl]                tcp_wfree
	 [curl]         skb_release_data
	 [curl]             kfree_skbmem



\[1\]: https://lore.kernel.org/bpf/20220811091526.172610-5-jolsa@kernel.org/

Fix #72 