### PR TITLE
Filter out non-available_filter_functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Docker images for `pwru` are published at https://hub.docker.com/r/cilium/pwru.
 An example how to run `pwru` with Docker:
 
 ```
-docker run --privileged --rm -t --pid=host cilium/pwru --filter-dst-ip=1.1.1.1
+docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/tracing:/sys/kernel/debug/tracing cilium/pwru --filter-dst-ip=1.1.1.1
 ```
 
 ### Running on Kubernetes


### PR DESCRIPTION
It is possible to attach the kprobes only to those functions which are listed in /sys/kernel/debug/tracing/available_filter_functions \[1\].

Previously, we tried to attach the kprobes to all functions. Attaching to a non-listed function failed with ENOENT which was not a problem, as we simply ignored such an error.

However, this becomes a problem with an introduction of the multi-link kprobes mechanism, as any invalid syms makes attachment to all other valid syms to fail.

\[1\]: https://www.kernel.org/doc/Documentation/trace/ftrace.rst

cc @vincentmli 

---

NB: it's non-trivial to fix the K8s example. I'm planning to do `mount -t debugfs none /sys/kernel/debug/` from `pwru`, so that no extra mounts are needed for K8s / Docker.