### PR TITLE
Update docker/Kubernetes deployment instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ An example how to run `pwru` with Docker:
 docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/tracing:/sys/kernel/debug/tracing cilium/pwru --filter-dst-ip=1.1.1.1
 ```
 
+Note: In case the path `/sys/kernel/debug/tracing` doesn't exist in the container, you can see error similar to 
+```
+docker: Error response from daemon: error while creating mount source path '/sys/kernel/debug/tracing': mkdir /sys/kernel/debug/tracing: no such file or directory
+```
+One way to avoid this is to mount the entire `/sys/kernel/debug` path from host to the container.
+```
+docker run --privileged --rm -t --pid=host -v /sys/kernel/debug:/sys/kernel/debug cilium/pwru --filter-dst-ip=1.1.1.1
+```
+
 ### Running on Kubernetes
 
 The following example shows how to run `pwru` on a given node:
@@ -88,6 +97,8 @@ kubectl run pwru \
     --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"kubernetes.io/hostname":"'$NODE'"}, "hostNetwork": true, "hostPID": true}}' \
     -- --filter-dst-ip=1.1.1.1 --output-tuple
 ```
+
+Note: You may need to create a volume for `/sys/kernel/debug/tracing` and mount it for the`pwru` pod. Similar to docker, if `/sys/kernel/debug/tracing` path doesn't exist in the container, mount entire `/sys/kernel/debug` to the container.
 
 ### Running on Vagrant
 


### PR DESCRIPTION
Using the current `Running pwru with Docker` command throws the following error in Ubuntu 22.04/22.10

```
$> docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/tracing:/sys/kernel/debug/tracing cilium/pwru --filter-dst-ip=1.1.1.1
    docker: Error response from daemon: error while creating mount source path '/sys/kernel/debug/tracing': mkdir /sys/kernel/debug/tracing: no such file or directory.
```

This is similar to the issue reported here: https://forums.docker.com/t/mount-subpath-of-debugfs/123525

One way to resolve this would be to mount the entire `/sys/kernel/debug` to the `pwru` container.

Similar error is surfaced when applying the Kubernetes spec mentioned in the README. I could get `pwru` running on Kubernetes node only after creating and attaching volume.

Signed-off-by: Anubhab Majumdar <anmajumdar@microsoft.com>