### PR TITLE
Update after renaming to `main` branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 Release process and checklist for `pwru`.
 
 This repository doesn't use release branches. All releases currently stem from
-the master branch.
+the `main` branch.
 
 ## Prepare the variables
 


### PR DESCRIPTION
This makes sure CI gets run on pull requests against `main`.