### PR TITLE
Fix IPv6 source filtering

### DIFF
--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -103,6 +103,7 @@ func ConfigBPFMap(flags *Flags, cfgMap *ebpf.Map) {
 
 		versionMatch := true
 		if ip4 := ip.To4(); ip4 == nil {
+			cfg.FilterIPv6 = 1
 			if cfg.FilterIPv6 <= 0 && flags.FilterDstIP != "" {
 				versionMatch = false
 			}


### PR DESCRIPTION
Previously, we didn't set the flag for ipv6 when only the src filter was given.