### PR TITLE
Print drop reason from kfree_skb_reason

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -62,6 +62,7 @@ struct event_t {
 	struct skb_meta meta;
 	struct tuple tuple;
 	s64 print_stack_id;
+	u64 param_second;
 	u32 cpu_id;
 } __attribute__((packed));
 
@@ -356,6 +357,7 @@ handle_everything(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip
 	event.skb_addr = (u64) skb;
 	event.ts = bpf_ktime_get_ns();
 	event.cpu_id = bpf_get_smp_processor_id();
+	event.param_second = PT_REGS_PARM2(ctx);
 
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
 

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -116,6 +116,7 @@ type Event struct {
 	Meta         Meta
 	Tuple        Tuple
 	PrintStackId int64
+	ParamSecond  uint64
 	CPU          uint32
 }
 

--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func main() {
 		file.Close()
 	}
 
-	output, err := pwru.NewOutput(&flags, printSkbMap, printStackMap, addr2name, useKprobeMulti)
+	output, err := pwru.NewOutput(&flags, printSkbMap, printStackMap, addr2name, useKprobeMulti, btfSpec)
 	if err != nil {
 		log.Fatalf("Failed to create outputer: %s", err)
 	}


### PR DESCRIPTION


This commit extracts a drop reason from kfree_skb_reason(), and prints
it when kfree_skb_reason() is called.

The helper was introduced in the v5.17. The second function param of it
contains a drop reason which is the "skb_drop_reason" enum. To extract
enum, we parse the kernel's BTF, as the enum is not considered as UAPI,
and there were already some position changes among its values.

An example output:

    0xffff936378692ce8 6 [curl]             nf_hook_slow 172.20.10.2:33918->1.1.1.1:4240(tcp)
    0xffff936378692ce8 6 [curl] kfree_skb_reason(SKB_DROP_REASON_NETFILTER_DROP) 172.20.10.2:33918->1.1.1.1:4240(tcp)

An alternative approach to passing the second param would have been to
set a BPF cookie when attaching the kprobe to the kfree_skb_reason().
However, that would require creating a new bpf/kprobe_pwru*.c, as
the helper bpf_get_attach_cookie() requires the bpf_link support, and
thus a newer kernel than the v5.3 (min required by pwru).

Fix #54 