### PR TITLE
bpf: make config as a constant

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -84,7 +84,7 @@ struct config {
 	u8 output_tuple;
 	u8 output_skb;
 	u8 output_stack;
-	u8 setted;
+	u8 is_set;
 } __attribute__((packed));
 
 static volatile const struct config CFG;
@@ -332,11 +332,11 @@ set_output(struct pt_regs *ctx, struct sk_buff *skb, struct event_t *event) {
 	}
 }
 
-static __always_inline int
+static __noinline int
 handle_everything(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip) {
 	struct event_t event = {};
 
-	if (cfg->setted) {
+	if (cfg->is_set) {
 		if (!filter(skb)) {
 			return 0;
 		}

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -84,8 +84,11 @@ struct config {
 	u8 output_tuple;
 	u8 output_skb;
 	u8 output_stack;
-	u8 pad;
+	u8 setted;
 } __attribute__((packed));
+
+static volatile const struct config CFG;
+#define cfg (&CFG)
 
 #define MAX_STACK_DEPTH 50
 struct {
@@ -94,13 +97,6 @@ struct {
 	__uint(key_size, sizeof(u32));
 	__uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
 } print_stack_map SEC(".maps");
-
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, struct config);
-} cfg_map SEC(".maps");
 
 #ifdef OUTPUT_SKB
 struct {
@@ -128,7 +124,7 @@ get_netns(struct sk_buff *skb) {
 }
 
 static __always_inline bool
-filter_meta(struct sk_buff *skb, struct config *cfg) {
+filter_meta(struct sk_buff *skb) {
 	if (cfg->netns && get_netns(skb) != cfg->netns) {
 			return false;
 	}
@@ -150,7 +146,7 @@ v6addr_equal(union addr addr, u8 bytes[16]) {
 }
 
 static __always_inline bool
-config_tuple_empty(struct config *cfg) {
+config_tuple_empty() {
 	if (!addr_empty(cfg->saddr) || !addr_empty(cfg->daddr)) {
 		return false;
 	}
@@ -165,8 +161,8 @@ config_tuple_empty(struct config *cfg) {
  * if one of the other fields does not match.
  */
 static __always_inline bool
-filter_l3_and_l4(struct sk_buff *skb, struct config *cfg) {
-	if (config_tuple_empty(cfg)) {
+filter_l3_and_l4(struct sk_buff *skb) {
+	if (config_tuple_empty()) {
 		return true;
 	}
 
@@ -245,8 +241,8 @@ filter_l3_and_l4(struct sk_buff *skb, struct config *cfg) {
 }
 
 static __always_inline bool
-filter(struct sk_buff *skb, struct config *cfg) {
-	return filter_meta(skb, cfg) && filter_l3_and_l4(skb, cfg);
+filter(struct sk_buff *skb) {
+	return filter_meta(skb) && filter_l3_and_l4(skb);
 }
 
 static __always_inline void
@@ -318,7 +314,7 @@ set_skb_btf(struct sk_buff *skb, typeof(print_skb_id) *event_id) {
 }
 
 static __always_inline void
-set_output(struct pt_regs *ctx, struct sk_buff *skb, struct event_t *event, struct config *cfg) {
+set_output(struct pt_regs *ctx, struct sk_buff *skb, struct event_t *event) {
 	if (cfg->output_meta) {
 		set_meta(skb, &event->meta);
 	}
@@ -340,15 +336,12 @@ static __always_inline int
 handle_everything(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip) {
 	struct event_t event = {};
 
-	u32 index = 0;
-	struct config *cfg = bpf_map_lookup_elem(&cfg_map, &index);
-
-	if (cfg) {
-		if (!filter(skb, cfg)) {
+	if (cfg->setted) {
+		if (!filter(skb)) {
 			return 0;
 		}
 
-		set_output(ctx, skb, &event, cfg);
+		set_output(ctx, skb, &event);
 	}
 
 	event.pid = bpf_get_current_pid_tgid();

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -38,14 +38,14 @@ type FilterCfg struct {
 	OutputSkb        uint8
 	OutputStack      uint8
 
-	Setted byte
+	IsSet byte
 }
 
 func GetConfig(flags *Flags) FilterCfg {
 	cfg := FilterCfg{
 		FilterNetns: flags.FilterNetns,
 		FilterMark:  flags.FilterMark,
-		Setted:      1,
+		IsSet:       1,
 	}
 	if flags.FilterPort > 0 {
 		cfg.FilterPort = byteorder.HostToNetwork16(flags.FilterPort)

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/cilium/ebpf"
-
 	"github.com/cilium/pwru/internal/byteorder"
 )
 
@@ -22,31 +20,32 @@ type FilterCfg struct {
 	FilterNetns uint32
 	FilterMark  uint32
 
-	//Filter l3
+	// Filter l3
 	FilterIPv6  uint8
 	FilterSrcIP [16]byte
 	FilterDstIP [16]byte
 
-	//Filter l4
+	// Filter l4
 	FilterProto   uint8
 	FilterSrcPort uint16
 	FilterDstPort uint16
 	FilterPort    uint16
 
-	//TODO: if there are more options later, then you can consider using a bit map
+	// TODO: if there are more options later, then you can consider using a bit map
 	OutputRelativeTS uint8
 	OutputMeta       uint8
 	OutputTuple      uint8
 	OutputSkb        uint8
 	OutputStack      uint8
 
-	Pad byte
+	Setted byte
 }
 
-func ConfigBPFMap(flags *Flags, cfgMap *ebpf.Map) {
+func GetConfig(flags *Flags) FilterCfg {
 	cfg := FilterCfg{
 		FilterNetns: flags.FilterNetns,
 		FilterMark:  flags.FilterMark,
+		Setted:      1,
 	}
 	if flags.FilterPort > 0 {
 		cfg.FilterPort = byteorder.HostToNetwork16(flags.FilterPort)
@@ -119,7 +118,5 @@ func ConfigBPFMap(flags *Flags, cfgMap *ebpf.Map) {
 		}
 	}
 
-	if err := cfgMap.Update(uint32(0), cfg, 0); err != nil {
-		log.Fatalf("Failed to set filter map: %v", err)
-	}
+	return cfg
 }

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -120,7 +120,6 @@ type Event struct {
 }
 
 type KProbeMaps interface {
-	GetCfgMap() *ebpf.Map
 	GetEvents() *ebpf.Map
 	GetPrintStackMap() *ebpf.Map
 }


### PR DESCRIPTION
Since 5.2 kernel, [bpf: implement lookup-free direct value access for maps](https://lore.kernel.org/bpf/20190409210910.32048-2-daniel@iogearbox.net/).

Then, use `bpf2bpf` to reduce .o file size.

Without `bpf2bpf`, the size of .o files:

```bash
-rwxrwx--- 1 root vboxsf 122K Feb  4 13:33 kprobemultipwru_bpfeb.o
-rwxrwx--- 1 root vboxsf 121K Feb  4 13:33 kprobemultipwru_bpfel.o
-rwxrwx--- 1 root vboxsf 117K Feb  4 13:34 kprobemultipwruwithoutoutputskb_bpfeb.o
-rwxrwx--- 1 root vboxsf 116K Feb  4 13:34 kprobemultipwruwithoutoutputskb_bpfel.o
-rwxrwx--- 1 root vboxsf 122K Feb  4 13:33 kprobepwru_bpfeb.o
-rwxrwx--- 1 root vboxsf 121K Feb  4 13:33 kprobepwru_bpfel.o
-rwxrwx--- 1 root vboxsf 117K Feb  4 13:34 kprobepwruwithoutoutputskb_bpfeb.o
-rwxrwx--- 1 root vboxsf 117K Feb  4 13:34 kprobepwruwithoutoutputskb_bpfel.o
```

With `bpf2bpf`, the size of .o files:

```bash
-rwxrwx--- 1 root vboxsf 67K Feb  4 14:05 kprobemultipwru_bpfeb.o
-rwxrwx--- 1 root vboxsf 67K Feb  4 14:05 kprobemultipwru_bpfel.o
-rwxrwx--- 1 root vboxsf 66K Feb  4 14:05 kprobemultipwruwithoutoutputskb_bpfeb.o
-rwxrwx--- 1 root vboxsf 66K Feb  4 14:05 kprobemultipwruwithoutoutputskb_bpfel.o
-rwxrwx--- 1 root vboxsf 67K Feb  4 14:05 kprobepwru_bpfeb.o
-rwxrwx--- 1 root vboxsf 67K Feb  4 14:05 kprobepwru_bpfel.o
-rwxrwx--- 1 root vboxsf 66K Feb  4 14:05 kprobepwruwithoutoutputskb_bpfeb.o
-rwxrwx--- 1 root vboxsf 66K Feb  4 14:05 kprobepwruwithoutoutputskb_bpfel.o
```

However, the cost is adding a bpf function call in runtime for every kprobe.

Without `bpf2bpf`, output of `bpftool prog dump xlated id ${PROGID}`:

```
int kprobe_skb_5(struct pt_regs * ctx):
; PWRU_ADD_KPROBE(5)
 0: (bf) r6 = r1
; PWRU_ADD_KPROBE(5)
 1: (79) r9 = *(u64 *)(r6 +72)
 2: (b7) r1 = 0
; struct event_t event = {};
; ...
```

With `bpf2bpf`, output of `bpftool prog dump xlated id ${PROGID}`:

```
int kprobe_skb_5(struct pt_regs * ctx):
; PWRU_ADD_KPROBE(5)
 0: (bf) r2 = r1
; PWRU_ADD_KPROBE(5)
 1: (79) r1 = *(u64 *)(r2 +72)
 2: (85) call pc+2#bpf_prog_6091cf2489a85a37_handle_everything
 3: (b7) r0 = 0
 4: (95) exit
int handle_everything(struct sk_buff * skb, struct pt_regs * ctx, bool has_get_func_ip):
; handle_everything(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip) {
 5: (bf) r6 = r2
 6: (bf) r7 = r1
 7: (b7) r1 = 0
; struct event_t event = {};
; ...
```