### PR TITLE
output: add absolute time to timestamp flag

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -11,12 +11,15 @@ import (
 	"os"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/cilium/ebpf"
 	ps "github.com/mitchellh/go-ps"
 
 	"github.com/cilium/pwru/internal/byteorder"
 )
+
+const absoluteTS string = "15:04:05.000"
 
 type output struct {
 	flags         *Flags
@@ -53,6 +56,9 @@ func NewOutput(flags *Flags, printSkbMap *ebpf.Map, printStackMap *ebpf.Map,
 }
 
 func (o *output) PrintHeader() {
+	if o.flags.OutputTS == "absolute" {
+		fmt.Fprintf(o.writer, "%12s ", "TIME")
+	}
 	fmt.Fprintf(o.writer, "%18s %6s %16s %24s", "SKB", "CPU", "PROCESS", "FUNC")
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %16s", "TIMESTAMP")
@@ -61,6 +67,9 @@ func (o *output) PrintHeader() {
 }
 
 func (o *output) Print(event *Event) {
+	if o.flags.OutputTS == "absolute" {
+		fmt.Fprintf(o.writer, "%12s ", time.Now().Format(absoluteTS))
+	}
 	p, err := ps.FindProcess(int(event.PID))
 	execName := "<empty>"
 	if err == nil && p != nil {

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -65,7 +65,7 @@ func (f *Flags) SetFlags() {
 	flag.Uint16Var(&f.FilterSrcPort, "filter-src-port", 0, "filter source port")
 	flag.Uint16Var(&f.FilterDstPort, "filter-dst-port", 0, "filter destination port")
 	flag.Uint16Var(&f.FilterPort, "filter-port", 0, "filter either destination or source port")
-	flag.StringVar(&f.OutputTS, "timestamp", "none", "print timestamp per skb (\"current\", \"relative\", \"none\")")
+	flag.StringVar(&f.OutputTS, "timestamp", "none", "print timestamp per skb (\"current\", \"relative\", \"absolute\", \"none\")")
 	flag.BoolVar(&f.OutputMeta, "output-meta", false, "print skb metadata")
 	flag.BoolVar(&f.OutputTuple, "output-tuple", false, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")


### PR DESCRIPTION
This patch adds "absolute" as a new value to the timestamp flag.
When set, it prefixes each line with the current time.

Closes #149