### PR TITLE
Updated Vagrantfile to use latest Ubuntu Image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,5 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/impish64"
-    config.vm.define :impish64
-    config.vm.hostname = "impish64"
+    config.vm.box = "generic/ubuntu2204"
     config.vm.synced_folder ".", "/pwru"
     config.vm.provision "shell", inline: <<-SHELL
       export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Ubuntu Impish has become end of life (July 14 2022), causing the Vagrantfile to fail.

This new ubuntu image is an LTS image. It is produced by [generic](https://app.vagrantup.com/generic) and has support for many vagrant providers (e.g. libvirt) while the official ubuntu boxes did not at this time.
