### PR TITLE
add tcp flag filtering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,8 @@ jobs:
             for addr in '1.0.0.1' '2606:4700:4700::1001'; do
               i=\$((i+1))
               port=8080
-              /host/pwru/pwru --filter-dst-ip="\$addr" --filter-port="\$port" --output-tuple \
+              /host/pwru/pwru --filter-dst-ip="\$addr" --filter-tcp-flags=syn --filter-port="\$port" \
+                --output-tuple \
                 --output-file=/tmp/pwru-\$i.log \
                 --ready-file=/tmp/pwru-\$i.ready 2>/tmp/pwru-\$i.status &
               PWRU_PID=\$!

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -99,15 +99,23 @@ func GetConfig(flags *Flags) FilterCfg {
 
 	if flags.FilterTcpFlags != "" {
 		split := strings.Split(flags.FilterTcpFlags, "/")
-		if len(split) != 2 {
+		switch len(split) {
+		case 1:
+			flags := split[0]
+			for _, flag := range strings.Split(flags, ",") {
+				cfg.FilterTcpFlags |= name2flag(flag)
+			}
+			cfg.FilterTcpFlagsMask = 0xff
+		case 2:
+			flags, mask := split[0], split[1]
+			for _, flag := range strings.Split(flags, ",") {
+				cfg.FilterTcpFlags |= name2flag(flag)
+			}
+			for _, flag := range strings.Split(mask, ",") {
+				cfg.FilterTcpFlagsMask |= name2flag(flag)
+			}
+		default:
 			log.Fatalf("Invalid --filter-tcp-flags format")
-		}
-		flags, mask := split[0], split[1]
-		for _, flag := range strings.Split(flags, ",") {
-			cfg.FilterTcpFlags |= name2flag(flag)
-		}
-		for _, flag := range strings.Split(mask, ",") {
-			cfg.FilterTcpFlagsMask |= name2flag(flag)
 		}
 		cfg.FilterProto = syscall.IPPROTO_TCP
 	}

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -59,7 +59,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.AllKMods, "all-kmods", false, "attach to all available kernel modules")
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
 	flag.StringVar(&f.FilterProto, "filter-proto", "", "filter L4 protocol (tcp, udp, icmp, icmp6)")
-	flag.StringVar(&f.FilterTcpFlags, "filter-tcp-flags", "", "filter tcp flags (flags/mask) e.g. \"SYN/SYN,ACK\". implies filter-proto tcp")
+	flag.StringVar(&f.FilterTcpFlags, "filter-tcp-flags", "", "filter tcp flags (flags or flags/mask) e.g. \"SYN\" or \"SYN/SYN,ACK\". implies filter-proto tcp")
 	flag.StringVar(&f.FilterSrcIP, "filter-src-ip", "", "filter source IP addr")
 	flag.StringVar(&f.FilterDstIP, "filter-dst-ip", "", "filter destination IP addr")
 	flag.Uint32Var(&f.FilterNetns, "filter-netns", 0, "filter netns inode")

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -24,15 +24,16 @@ type Flags struct {
 
 	KernelBTF string
 
-	FilterNetns   uint32
-	FilterMark    uint32
-	FilterFunc    string
-	FilterProto   string
-	FilterSrcIP   string
-	FilterDstIP   string
-	FilterSrcPort uint16
-	FilterDstPort uint16
-	FilterPort    uint16
+	FilterNetns    uint32
+	FilterMark     uint32
+	FilterFunc     string
+	FilterProto    string
+	FilterTcpFlags string
+	FilterSrcIP    string
+	FilterDstIP    string
+	FilterSrcPort  uint16
+	FilterDstPort  uint16
+	FilterPort     uint16
 
 	OutputTS         string
 	OutputMeta       bool
@@ -58,6 +59,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.AllKMods, "all-kmods", false, "attach to all available kernel modules")
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
 	flag.StringVar(&f.FilterProto, "filter-proto", "", "filter L4 protocol (tcp, udp, icmp, icmp6)")
+	flag.StringVar(&f.FilterTcpFlags, "filter-tcp-flags", "", "filter tcp flags (flags/mask) e.g. \"SYN/SYN,ACK\". implies filter-proto tcp")
 	flag.StringVar(&f.FilterSrcIP, "filter-src-ip", "", "filter source IP addr")
 	flag.StringVar(&f.FilterDstIP, "filter-dst-ip", "", "filter destination IP addr")
 	flag.Uint32Var(&f.FilterNetns, "filter-netns", 0, "filter netns inode")


### PR DESCRIPTION
Add a new option for filtering using TCP Flags. semantics is similar to iptables. You provide a set of flags and a mask to test the flags with.

I havn't seen existing tests for filtering logic, so would appreciate some insight on how to best tests this. I've ran it manually and it seems to work.