### PR TITLE
Track skb by address

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -22,6 +22,8 @@
 #define ETH_P_IP              0x800
 #define ETH_P_IPV6            0x86dd
 
+const static bool TRUE = true;
+
 union addr {
 	u32 v4addr;
 	struct {
@@ -70,6 +72,14 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 } events SEC(".maps");
 
+#define MAX_TRACK_SIZE 1024
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u64);
+	__type(value, bool);
+	__uint(max_entries, MAX_TRACK_SIZE);
+} skb_addresses SEC(".maps");
+
 struct config {
 	u32 netns;
 	u32 mark;
@@ -86,6 +96,7 @@ struct config {
 	u8 output_skb;
 	u8 output_stack;
 	u8 is_set;
+	u8 track_skb;
 } __attribute__((packed));
 
 static volatile const struct config CFG;
@@ -336,19 +347,30 @@ set_output(struct pt_regs *ctx, struct sk_buff *skb, struct event_t *event) {
 
 static __noinline int
 handle_everything(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip) {
+	bool tracked = false;
 	struct event_t event = {};
+	event.skb_addr = (u64) skb;
 
 	if (cfg->is_set) {
+		if (cfg->track_skb && bpf_map_lookup_elem(&skb_addresses, &event.skb_addr)) {
+			tracked = true;
+			goto cont;
+		}
+
 		if (!filter(skb)) {
 			return 0;
 		}
 
+cont:
 		set_output(ctx, skb, &event);
+	}
+
+	if (cfg->track_skb && !tracked) {
+		bpf_map_update_elem(&skb_addresses, &event.skb_addr, &TRUE, BPF_ANY);
 	}
 
 	event.pid = bpf_get_current_pid_tgid();
 	event.addr = has_get_func_ip ? bpf_get_func_ip(ctx) : PT_REGS_IP(ctx);
-	event.skb_addr = (u64) skb;
 	event.ts = bpf_ktime_get_ns();
 	event.cpu_id = bpf_get_smp_processor_id();
 	event.param_second = PT_REGS_PARM2(ctx);

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -38,7 +38,8 @@ type FilterCfg struct {
 	OutputSkb        uint8
 	OutputStack      uint8
 
-	IsSet byte
+	IsSet    byte
+	TrackSkb byte
 }
 
 func GetConfig(flags *Flags) FilterCfg {

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -127,5 +127,9 @@ func GetConfig(flags *Flags) FilterCfg {
 		}
 	}
 
+	if flags.FilterTrackSkb {
+		cfg.TrackSkb = 1
+	}
+
 	return cfg
 }

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -24,15 +24,16 @@ type Flags struct {
 
 	KernelBTF string
 
-	FilterNetns   uint32
-	FilterMark    uint32
-	FilterFunc    string
-	FilterProto   string
-	FilterSrcIP   string
-	FilterDstIP   string
-	FilterSrcPort uint16
-	FilterDstPort uint16
-	FilterPort    uint16
+	FilterNetns    uint32
+	FilterMark     uint32
+	FilterFunc     string
+	FilterProto    string
+	FilterSrcIP    string
+	FilterDstIP    string
+	FilterSrcPort  uint16
+	FilterDstPort  uint16
+	FilterPort     uint16
+	FilterTrackSkb bool
 
 	OutputTS         string
 	OutputMeta       bool
@@ -72,6 +73,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
 	flag.IntVar(&f.PerCPUBuffer, "per-cpu-buffer", os.Getpagesize(), "per CPU buffer in bytes")
+	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 
 	flag.StringVar(&f.OutputFile, "output-file", "", "write traces to file")
 


### PR DESCRIPTION
This PR introduces a bpf map to store matched skb addresses, so for any skb whose address can be found in the map, we see it a matched one without filter check.

This can be useful to observe NAT-ed / encrypted / encapsulated traffic.

Fixes: #84 

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>