### PR TITLE
Drop legacy filter flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,9 +92,10 @@ jobs:
             for addr in '1.0.0.1' '2606:4700:4700::1001'; do
               i=\$((i+1))
               port=8080
-              /host/pwru/pwru --filter-dst-ip="\$addr" --filter-port="\$port" --output-tuple \
+              /host/pwru/pwru --output-tuple \
                 --output-file=/tmp/pwru-\$i.log \
-                --ready-file=/tmp/pwru-\$i.ready 2>/tmp/pwru-\$i.status &
+                --ready-file=/tmp/pwru-\$i.ready \
+                "dst host \$addr and port \$port" 2>/tmp/pwru-\$i.status &
               PWRU_PID=\$!
 
               while [ ! -f /tmp/pwru-\$i.ready ]; do sleep 1; done

--- a/README.md
+++ b/README.md
@@ -46,19 +46,14 @@ You can download the statically linked executable for x86\_64 and arm64 from the
 
 ```
 $ ./pwru --help
-Usage of ./pwru:
+Usage: pwru [options] [pcap-filter]
+    Availble pcap-filter: see "man 7 pcap-filter"
+    Availble options:
       --all-kmods                 attach to all available kernel modules
       --backend string            Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
-      --filter-dst-ip string      filter destination IP addr
-      --filter-dst-port uint16    filter destination port
       --filter-func string        filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
       --filter-mark uint32        filter skb mark
       --filter-netns uint32       filter netns inode
-      --filter-pcap string        filter by pcap-filter expression
-      --filter-port uint16        filter either destination or source port
-      --filter-proto string       filter L4 protocol (tcp, udp, icmp, icmp6)
-      --filter-src-ip string      filter source IP addr
-      --filter-src-port uint16    filter source port
       --filter-track-skb          trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
       --kernel-btf string         specify kernel BTF file
       --kmods strings             list of kernel modules names to attach to
@@ -71,6 +66,7 @@ Usage of ./pwru:
       --per-cpu-buffer int        per CPU buffer in bytes (default 4096)
       --timestamp string          print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
       --version                   show pwru version and exit
+
 ```
 
 If multiple filters are specified, all of them have to match in order for a
@@ -87,7 +83,7 @@ Docker images for `pwru` are published at https://hub.docker.com/r/cilium/pwru.
 An example how to run `pwru` with Docker:
 
 ```
-docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/:/sys/kernel/debug/ cilium/pwru --filter-dst-ip=1.1.1.1
+docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/:/sys/kernel/debug/ cilium/pwru 'dst host 1.1.1.1'
 ```
 
 ### Running on Kubernetes
@@ -100,7 +96,7 @@ kubectl run pwru \
     --privileged=true \
     --attach=true -i=true --tty=true --rm=true \
     --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"kubernetes.io/hostname":"'$NODE'"}, "hostNetwork": true, "hostPID": true}}' \
-    -- --filter-dst-ip=1.1.1.1 --output-tuple
+    -- --output-tuple 'dst host 1.1.1.1'
 ```
 
 Note: You may need to create a volume for `/sys/kernel/debug/` and mount it for the`pwru` pod.

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -3,16 +3,6 @@
 /* Copyright (C) 2021 Authors of Cilium */
 
 /*
- * TODO: ipv6 l4 protocol
- * According to https://www.rfc-editor.org/rfc/rfc2460, in ipv6 header, the
- * transport layer protocol is represented by the Next Header field. However
- * ipv6 supports extension headers and recommends to place the transport layer
- * protocol at last. So if we want to parse out the transport layer protocol,
- * we have to identify all the extension headers, which is quite troublesome.
- * Currently it is assumed that there are no ipv6 extension headers.
- */
-
-/*
  * WARNING: `bpf_printk()` has special intention in this program: it is used for
  * pcap-filter ebpf injection, please see the comment in the `filter_pcap()`. So
  * if you want to add additional `bpf_printk()` for debugging, it is likely to

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -22,7 +22,7 @@ above example with the following commands.
 
 4. Run `pwru`:
    ```console
-   $ sudo ./pwru --filter-dst-ip=1.1.1.1 --filter-dst-port=80 --filter-proto=tcp --output-tuple
+   $ sudo ./pwru --output-tuple 'dst host 1.1.1.1 and dst port 80 and tcp'
    ```
 
 5. In a new terminal (terminal 2), connect to the Vagrant box:

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -4,11 +4,6 @@
 
 package pwru
 
-import (
-	"fmt"
-	"strings"
-)
-
 // Version is the pwru version and is set at compile time via LDFLAGS-
 var Version string = "version unknown"
 
@@ -51,40 +46,4 @@ func GetConfig(flags *Flags) FilterCfg {
 	}
 
 	return cfg
-}
-
-func GetPcapFilter(flags *Flags) string {
-	filters := []string{}
-	if flags.FilterPcap != "" {
-		filters = append(filters, flags.FilterPcap)
-	}
-
-	if flags.FilterProto != "" {
-		filters = append(filters, strings.ToLower(flags.FilterProto))
-	}
-
-	if flags.FilterSrcIP != "" {
-		filters = append(filters, "src host "+flags.FilterSrcIP)
-	}
-
-	if flags.FilterDstIP != "" {
-		filters = append(filters, "dst host "+flags.FilterDstIP)
-	}
-
-	if flags.FilterSrcPort != 0 {
-		filters = append(filters, fmt.Sprintf("src port %d", flags.FilterSrcPort))
-	}
-
-	if flags.FilterDstPort != 0 {
-		filters = append(filters, fmt.Sprintf("dst port %d", flags.FilterDstPort))
-	}
-
-	if flags.FilterPort != 0 {
-		filters = append(filters, fmt.Sprintf("port %d", flags.FilterPort))
-	}
-
-	for i, filter := range filters {
-		filters[i] = "(" + filter + ")"
-	}
-	return strings.Join(filters, " and ")
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
-	flag "github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/pwru/internal/pwru"
@@ -29,7 +28,7 @@ import (
 func main() {
 	flags := pwru.Flags{}
 	flags.SetFlags()
-	flag.Parse()
+	flags.Parse()
 
 	if flags.ShowVersion {
 		fmt.Printf("pwru %s\n", pwru.Version)
@@ -125,7 +124,7 @@ func main() {
 	}
 
 	for name, program := range bpfSpec.Programs {
-		if err = libpcap.InjectFilter(program, pwru.GetPcapFilter(&flags)); err != nil {
+		if err = libpcap.InjectFilter(program, flags.FilterPcap); err != nil {
 			log.Fatalf("Failed to inject filter ebpf for %s: %v", name, err)
 		}
 	}


### PR DESCRIPTION
This commit allows users to specify the filter pcap in the same way as with tcpdump. For example, `pwru --output-tuple 'host 1.1.1.1 and port 80'`.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>