### PR TITLE
Fix wrong StackOffset for converting cbpf to ebpf

### DIFF
--- a/libpcap/inject.go
+++ b/libpcap/inject.go
@@ -162,7 +162,7 @@ func InjectFilter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
 		// stack area is safe to use. Here we use stack from -40
 		// because -32, -24, -16 are reserved for pcap-filter ebpf, see
 		// the comments in compile.go
-		StackOffset: -40,
+		StackOffset: 40,
 	})
 	if err != nil {
 		return


### PR DESCRIPTION
The idea had no flaw but the offset should be 40 instead of -40, or generated ebpf will try to read r10+32 instead of r10-48.

Caught this bug by running examples from "man 7 pcap-filter":

```shell
while read -r expr; do 
    echo "$expr"; 
    sudo pwru --output-limit-lines 1 "$expr"; 
done <<<"$(man 7 pcap-filter | awk '/EXAMPLES/,/BACKWARD/'  | grep -P '^\s{14}')"
```

Fixes: https://github.com/cilium/pwru/pull/198

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>