### PR TITLE
Minor fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Usage: pwru [options] [pcap-filter]
       --output-skb                print skb
       --output-stack              print stack
       --output-tuple              print L4 tuple
-      --per-cpu-buffer int        per CPU buffer in bytes (default 4096)
       --timestamp string          print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
       --version                   show pwru version and exit
 

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -39,9 +39,8 @@ type Flags struct {
 	OutputLimitLines uint64
 	OutputFile       string
 
-	PerCPUBuffer int
-	KMods        []string
-	AllKMods     bool
+	KMods    []string
+	AllKMods bool
 
 	ReadyFile string
 
@@ -62,7 +61,6 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
-	flag.IntVar(&f.PerCPUBuffer, "per-cpu-buffer", os.Getpagesize(), "per CPU buffer in bytes")
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 
 	flag.StringVar(&f.OutputFile, "output-file", "", "write traces to file")

--- a/libpcap/compile.go
+++ b/libpcap/compile.go
@@ -194,7 +194,7 @@ func adjustEbpf(insts asm.Instructions, opts cbpfc.EBPFOpts) (newInsts asm.Instr
 	insts = append(insts,
 		asm.Mov.Imm(asm.R0, 0).WithSymbol("result"), // r0 = 0
 		asm.JNE.Imm(opts.Result, 0, "continue"),     // if %result != 0 (match): jump to continue
-		asm.Return().WithSymbol("return"),           // else return TC_ACT_OK
+		asm.Return().WithSymbol("return"),           // else return r0
 		asm.Mov.Imm(asm.R0, 0).WithSymbol("continue"),
 	)
 

--- a/main.go
+++ b/main.go
@@ -161,8 +161,6 @@ func main() {
 		printSkbMap = objs.(pwru.KProbeMapsWithOutputSKB).GetPrintSkbMap()
 	}
 
-	log.Printf("Per cpu buffer size: %d bytes\n", flags.PerCPUBuffer)
-
 	var kprobes []link.Link
 	defer func() {
 		select {


### PR DESCRIPTION
1. Delete obsolete perf flag `--perf-cpu-buffer`
2. s/TC_ACT_OK/r0/

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>