### PR TITLE
fix: don't compile libpcap RDMA support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(TARGET): libpcap/libpcap.a
 
 libpcap/libpcap.a:
 	cd libpcap && \
-		CC=$(LIBPCAP_CC) ./configure --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --host=$(LIBPCAP_ARCH) && \
+		CC=$(LIBPCAP_CC) ./configure --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --host=$(LIBPCAP_ARCH) && \
 		make
 
 release:


### PR DESCRIPTION
Solves build error:

```
% make
TARGET_GOARCH=amd64 go generate
Generating for amd64
Compiled /tmp/pwru/kprobepwru_bpfel_x86.o
Stripped /tmp/pwru/kprobepwru_bpfel_x86.o
Wrote /tmp/pwru/kprobepwru_bpfel_x86.go
Compiled /tmp/pwru/kprobemultipwru_bpfel_x86.o
Stripped /tmp/pwru/kprobemultipwru_bpfel_x86.o
Wrote /tmp/pwru/kprobemultipwru_bpfel_x86.go
Compiled /tmp/pwru/kprobepwruwithoutoutputskb_bpfel_x86.o
Stripped /tmp/pwru/kprobepwruwithoutoutputskb_bpfel_x86.o
Wrote /tmp/pwru/kprobepwruwithoutoutputskb_bpfel_x86.go
Compiled /tmp/pwru/kprobemultipwruwithoutoutputskb_bpfel_x86.o
Stripped /tmp/pwru/kprobemultipwruwithoutoutputskb_bpfel_x86.o
Wrote /tmp/pwru/kprobemultipwruwithoutoutputskb_bpfel_x86.go
Wrote kprobemultipwru_bpfel_x86_getter.go
Wrote kprobemultipwruwithoutoutputskb_bpfel_x86_getter.go
Wrote kprobepwru_bpfel_x86_getter.go
Wrote kprobepwruwithoutoutputskb_bpfel_x86_getter.go
CC=cc GOARCH=amd64 CGO_ENABLED=1 go build  \
	-ldflags "-w -s \
	-X 'github.com/cilium/pwru/internal/pwru.Version=bc07418'"
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(nametoaddr.o): in function `pcap_nametoaddrinfo':
/tmp/pwru/libpcap/./nametoaddr.c:207: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(nametoaddr.o): in function `pcap_nametoaddr':
/tmp/pwru/libpcap/./nametoaddr.c:181: warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(nametoaddr.o): in function `pcap_nametonetaddr':
/tmp/pwru/libpcap/./nametoaddr.c:270: warning: Using 'getnetbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(nametoaddr.o): in function `pcap_nametoproto':
/tmp/pwru/libpcap/./nametoaddr.c:527: warning: Using 'getprotobyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_read':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:126: undefined reference to `ibv_get_cq_event'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:135: undefined reference to `ibv_ack_cq_events'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:162: undefined reference to `ibv_wc_status_str'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_activate':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:214: undefined reference to `ibv_open_device'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:221: undefined reference to `ibv_alloc_pd'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:228: undefined reference to `ibv_create_comp_channel'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:235: undefined reference to `ibv_create_cq'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:250: undefined reference to `ibv_create_qp'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:260: undefined reference to `ibv_modify_qp'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:268: undefined reference to `ibv_modify_qp'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `__ibv_reg_mr':
/usr/include/infiniband/verbs.h:2535: undefined reference to `ibv_reg_mr'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_activate':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:338: undefined reference to `ibv_dereg_mr'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:346: undefined reference to `ibv_destroy_qp'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:350: undefined reference to `ibv_destroy_cq'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:354: undefined reference to `ibv_destroy_comp_channel'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:358: undefined reference to `ibv_dealloc_pd'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:362: undefined reference to `ibv_close_device'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `___ibv_query_port':
/usr/include/infiniband/verbs.h:2359: undefined reference to `ibv_query_port'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_cleanup':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:83: undefined reference to `ibv_dereg_mr'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:85: undefined reference to `ibv_destroy_qp'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:86: undefined reference to `ibv_destroy_cq'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:87: undefined reference to `ibv_dealloc_pd'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:88: undefined reference to `ibv_destroy_comp_channel'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:89: undefined reference to `ibv_close_device'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_create':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:386: undefined reference to `ibv_get_device_list'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:425: undefined reference to `ibv_free_device_list'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:391: undefined reference to `ibv_free_device_list'
/usr/bin/ld: internal/libpcap/../../libpcap/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_findalldevs':
/tmp/pwru/libpcap/./pcap-rdmasniff.c:437: undefined reference to `ibv_get_device_list'
/usr/bin/ld: /tmp/pwru/libpcap/./pcap-rdmasniff.c:453: undefined reference to `ibv_free_device_list'
collect2: error: ld returned 1 exit status
make: *** [Makefile:19: pwru] Error 2
zsh: exit 2     make
```

Another option can be to add libibverbs to link options.

Signed-off-by: Nerijus Bendžiūnas <nerijus.bendziunas@gmail.com>