### PR TITLE
Stop tracking skb in the end of its lifetime

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -162,7 +162,7 @@ filter_pcap(struct sk_buff *skb) {
 	 * 3. mark the position to inject pcap filter ebpf instructions;
 	 */
 	bpf_printk("%d %d", data, data_end);
-	return data < data_end;
+	return data != data_end;
 }
 
 static __always_inline bool

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -321,4 +321,13 @@ PWRU_ADD_KPROBE(5)
 #undef PWRU_HAS_GET_FUNC_IP
 #undef PWRU_KPROBE_TYPE
 
+SEC("kprobe/skb_lifetime_termination")
+int kprobe_skb_lifetime_termination(struct pt_regs *ctx) {
+	u64 skb = (u64) PT_REGS_PARM1(ctx);
+	if (cfg->track_skb)
+		bpf_map_delete_elem(&skb_addresses, &skb);
+
+	return 0;
+}
+
 char __license[] SEC("license") = "Dual BSD/GPL";

--- a/internal/libpcap/compile.go
+++ b/internal/libpcap/compile.go
@@ -191,12 +191,11 @@ func adjustEbpf(insts asm.Instructions, opts cbpfc.EBPFOpts) (newInsts asm.Instr
 		asm.Mov.Imm(asm.R3, 0),
 	}, insts...)
 
-	// Append instructions to implement "exit immediately if not matched"
 	insts = append(insts,
 		asm.Mov.Imm(asm.R0, 0).WithSymbol("result"), // r0 = 0
-		asm.JNE.Imm(opts.Result, 0, "continue"),     // if %result != 0 (match): jump to continue
-		asm.Return().WithSymbol("return"),           // else return r0
-		asm.Mov.Imm(asm.R0, 0).WithSymbol("continue"),
+		asm.Mov.Reg(opts.PacketStart, opts.Result),  // skb->data = $result
+		asm.Mov.Imm(opts.PacketEnd, 0),              // skb->data_end = 0
+
 	)
 
 	return insts, nil

--- a/internal/libpcap/inject.go
+++ b/internal/libpcap/inject.go
@@ -174,15 +174,9 @@ func InjectFilter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
 					    91:       r3 = r9
 					    92:       r4 = r8
 		    injectIdx ->	    93:       call 6
-					;       return filter_pcap(skb) && filter_meta(skb);
-		    injectIdx+1 ->	    94:       if r9 >= r8 goto +384 <LBB1_39>
-
-		    [injectIdx-4:injectIdx] is compiled from bpf_printk();
-		    [injectIdx+1] is from `return data < data_end` statement;
-		    both statements shall be replaced by pcap filter instructions.
 	*/
 	program.Instructions = append(program.Instructions[:injectIdx-4],
-		append(filterEbpf, program.Instructions[injectIdx+2:]...)...,
+		append(filterEbpf, program.Instructions[injectIdx+1:]...)...,
 	)
 
 	return nil

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -138,6 +138,7 @@ type KProbePrograms interface {
 	GetKprobeSkb3() *ebpf.Program
 	GetKprobeSkb4() *ebpf.Program
 	GetKprobeSkb5() *ebpf.Program
+	GetKprobeSkbLifetimeTermination() *ebpf.Program
 }
 
 type KProbeObjects interface {


### PR DESCRIPTION
`--filter-track-skb` has a problem of mismatching skbs with same pointer address. This PR tries to fix it by stopping tracking after an skb ends its lifetime.

In general, an skb has 3 possible endings:
1. consumed locally
2. dropped locally
3. transferred via a netdev

All the three endings hit `kfree_skbmem` eventually, so we delete tracked skb pointer address from bpf map at that time.

Fixes: https://github.com/cilium/pwru/pull/194

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>