### PR TITLE
Raise rlimit nofile to 8192

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func main() {
 	}
 
 	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{
-		Cur: 4096,
-		Max: 4096,
+		Cur: 8192,
+		Max: 8192,
 	}); err != nil {
 		log.Fatalf("failed to set temporary rlimit: %s", err)
 	}


### PR DESCRIPTION
Previous limit 4096 isn't enough for `--all-kmods`, lsof shows pwru uses as many as 5269 fds in that case.

Siged-off-by: Zhichuan Liang <gray.liang@isovalent.com>