### PR TITLE
Use bpf2bpf to simplify injection

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,10 +2,10 @@
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang KProbeMultiPWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -DHAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang KProbeMultiPWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D HAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -DHAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D HAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
 //go:generate go run ./tools/getgetter.go -struct ^(KProbePWRU|KProbeMultiPWRU|KProbePWRUWithoutOutputSKB|KProbeMultiPWRUWithoutOutputSKB)(Programs|Maps)$
 
 package main

--- a/internal/libpcap/inject.go
+++ b/internal/libpcap/inject.go
@@ -35,13 +35,7 @@ func InjectFilter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
 		// R0-R3 are also safe to use thanks to the placeholder parameters _skb, __skb, ___skb.
 		Working:     [4]asm.Register{asm.R0, asm.R1, asm.R2, asm.R3},
 		LabelPrefix: "filter",
-		// In the kprobe_pwru.c:handle_everything, the first line of
-		// code `struct event_t event = {}` initializes stack [r10-136,
-		// r10-16] with zero value, so during the filtering stage, this
-		// stack area is safe to use. Here we use stack from -40
-		// because -32, -24, -16 are reserved for pcap-filter ebpf, see
-		// the comments in compile.go
-		StackOffset: 48,
+		StackOffset: -int(AvailableOffset),
 	})
 	if err != nil {
 		return

--- a/internal/libpcap/inject.go
+++ b/internal/libpcap/inject.go
@@ -2,158 +2,37 @@ package libpcap
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cloudflare/cbpfc"
 )
 
-/*
-Steps:
-1. Find the injection position, which is the bpf_printk call
-2. Make some necessary preparations for the injection
-3. Compile the filter expression into ebpf instructions
-4. Inject the instructions
-*/
 func InjectFilter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
-	/*
-	   First let's mark references and symbols for the jump instructions.
-	   This is even required when filterExpr is empty, because we still
-	   need to remove the bpf_printk call in that case, which breaks the
-	   jump instructions as well.
-	*/
-	injectIdx := 0
-	for idx, inst := range program.Instructions {
-		// In the kprobe_pwru.c, we deliberately put a bpf_printk call to mark the injection position, see the comments over there.
-		if inst.OpCode.JumpOp() == asm.Call && inst.Constant == int64(asm.FnTracePrintk) {
-			injectIdx = idx
-			break
-		}
-
-		/*
-			As we are injecting a bunch of instructions into the
-			program, the jump instructions are likely to require
-			adjustments on their pc-related offsets. For example,
-			we have the original bpf program as follows:
-
-			26: 	 if r9 >= r8 goto +384 <LBB1_39>
-			...
-			96: 	 call bpf_trace_printk#6
-			...
-
-			After the injection, the instruction No.96 is replaced
-			by multiple instructions, leaving the instruction No.26
-			jumping to a wrong instruction. The offset should be
-			adjusted accordingly!
-
-			We solve this problem smart way by using references and
-			symbols. The code below sets -1 to the affected jump
-			instructions' offsets, adds necessary symbols and
-			references, let cilium/ebpf collectionLoader adjust the
-			offsets according to these additional information. This
-			way, we don't have to calculate the new offsets by
-			hand, which is extremely likely to mess up.
-		*/
-		if inst.OpCode.Class().IsJump() {
-			// Zero jump offset implies a function call, leave it alone
-			if inst.Offset == 0 {
-				continue
-			}
-
-			// If there already is a reference and corresponding
-			// symbol, we don't have to create new symbol, just set -1
-			// to the offset so that cilium/ebpf loader can adjust it.
-			if inst.Reference() != "" {
-				program.Instructions[idx].Offset = -1
-				continue
-			}
-
-			var gotoIns *asm.Instruction
-			iter := asm.Instructions(program.Instructions[idx+1:]).Iterate()
-			for iter.Next() {
-				if int16(iter.Offset) == inst.Offset {
-					gotoIns = iter.Ins
-					break
-				}
-			}
-			if gotoIns == nil {
-				return errors.New("Cannot find the jump target")
-			}
-			symbol := gotoIns.Symbol()
-			if symbol == "" {
-				symbol = fmt.Sprintf("PWRU_%d", idx)
-				*gotoIns = gotoIns.WithSymbol(symbol)
-			}
-			program.Instructions[idx] = program.Instructions[idx].WithReference(symbol)
-			program.Instructions[idx].Offset = -1
-		}
-	}
-	if injectIdx == 0 {
-		return errors.New("Cannot find the injection position")
-	}
-
 	if filterExpr == "" {
-		/*
-		   No need to inject anything, just remove the bpf_printk call
-		   to avoid the unnecessary overhead.
-
-		   bpf_printk() compiles to 5 instructions from index idx-4 to
-		   idx: the former 4 are setting up registers from R1 to R4,
-		   the last one calls printk().
-
-		   But we can't delete former 4 instructions, otherwise we'll
-		   hit verifier with "R1 !read_ok"; they're required to stay
-		   there for register initialization.
-		*/
-		program.Instructions = append(program.Instructions[:injectIdx],
-			program.Instructions[injectIdx+1:]...,
-		)
 		return
 	}
 
-	/*
-		Conversion from cbpf to ebpf requires indication of the packet
-		start and end positions. These two position should be held by
-		two registers, thanks to the `bpf_printk("..", start, end)`
-		statement, which makes it clear that start is at R3 and end is
-		at R4.
-		The code below searches the instructions prior to the
-		injection position to find the registers holding the packet
-		start and end positions, by looking for the mov instructions
-		targeting R3 and R4.
-	*/
-	var (
-		dataReg    asm.Register = 255
-		dataEndReg asm.Register = 255
-	)
-	for idx := injectIdx - 1; idx >= 0; idx-- {
-		inst := program.Instructions[idx]
-		if inst.OpCode.ALUOp() == asm.Mov {
-			if inst.Dst == asm.R3 {
-				dataReg = inst.Src
-			} else if inst.Dst == asm.R4 {
-				dataEndReg = inst.Src
-			}
-		}
-		if dataReg != 255 && dataEndReg != 255 {
+	injectIdx := -1
+	for idx, inst := range program.Instructions {
+		if inst.Symbol() == "filter_pcap_ebpf" {
+			injectIdx = idx
 			break
 		}
 	}
-	if dataReg == 255 || dataEndReg == 255 {
-		return errors.New("Cannot find the data / data_end registers")
+	if injectIdx == -1 {
+		return errors.New("Cannot find the injection position")
 	}
 
 	filterEbpf, err := CompileEbpf(filterExpr, cbpfc.EBPFOpts{
-		PacketStart: dataReg,
-		PacketEnd:   dataEndReg,
-		// R4 is safe to use, because at the injection position, we are
-		// originally preparing to perform a bpf-helper func call with 4
-		// arguments, which leaves r0, r1, r2, r3 and r4 registers ready
-		// to use.
-		Result:      asm.R4,
+		// The rejection position is in the beginning of the `filter_pcap_ebpf` function:
+		// filter_pcap_ebpf(void *_skb, void *__skb, void *___skb, void *data, void* data_end)
+		// So we can confidently say, skb->data is at r4, skb->data_end is at r5.
+		PacketStart: asm.R4,
+		PacketEnd:   asm.R5,
+		Result:      asm.R0,
 		ResultLabel: "result",
-		// Same reason stated above, r0, r1, r2, r3 are safe to use.
+		// R0-R3 are also safe to use thanks to the placeholder parameters _skb, __skb, ___skb.
 		Working:     [4]asm.Register{asm.R0, asm.R1, asm.R2, asm.R3},
 		LabelPrefix: "filter",
 		// In the kprobe_pwru.c:handle_everything, the first line of
@@ -162,21 +41,16 @@ func InjectFilter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
 		// stack area is safe to use. Here we use stack from -40
 		// because -32, -24, -16 are reserved for pcap-filter ebpf, see
 		// the comments in compile.go
-		StackOffset: 32,
+		StackOffset: 48,
 	})
 	if err != nil {
 		return
 	}
-	/*
-					;       bpf_printk("%d %d", data, data_end);
-		    injectIdx-4 ->	    88:       r1 = 54 ll
-					    90:       r2 = 6
-					    91:       r3 = r9
-					    92:       r4 = r8
-		    injectIdx ->	    93:       call 6
-	*/
-	program.Instructions = append(program.Instructions[:injectIdx-4],
-		append(filterEbpf, program.Instructions[injectIdx+1:]...)...,
+
+	filterEbpf[0] = filterEbpf[0].WithMetadata(program.Instructions[injectIdx].Metadata)
+	program.Instructions[injectIdx] = program.Instructions[injectIdx].WithMetadata(asm.Metadata{})
+	program.Instructions = append(program.Instructions[:injectIdx],
+		append(filterEbpf, program.Instructions[injectIdx:]...)...,
 	)
 
 	return nil


### PR DESCRIPTION
By using bpf2bpf:

1. We don't have to search for registers holding skb->data and skb-data_end, because they must be at R4 and R5 as arguments.
2. We no longer need a bpf_printk() to be replaced, so pwru developers can use printk for debugging again.
3. We don't need to assume clang behavior or rely on specific clang version.
4. We can delete a lot of code to simplify logic.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>