### PR TITLE
Add --filter-ifname

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,16 @@ jobs:
             ping -W1 -c1 10.0.0.1 || true
           expected-output-pattern: 'arp_rcv'
 
+      - name: Test --filter-ifname
+        uses: ./.github/actions/pwru-test
+        with:
+          test-name: filter-ifname
+          pwru-flags: --filter-ifname lo
+          pwru-pcap-filter: icmp
+          traffic-setup: |
+            ping -W1 -c1 127.0.0.1 || true
+          expected-output-pattern: 'icmp'
+
       - name: Fetch artifacts
         if: ${{ !success() }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage: pwru [options] [pcap-filter]
       --backend string            Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
       --filter-func string        filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
       --filter-mark uint32        filter skb mark
-      --filter-netns uint32       filter netns inode
+      --filter-netns string       filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
       --filter-track-skb          trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
       --kernel-btf string         specify kernel BTF file
       --kmods strings             list of kernel modules names to attach to

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -77,6 +77,7 @@ struct {
 struct config {
 	u32 netns;
 	u32 mark;
+	u32 ifindex;
 	u8 output_timestamp;
 	u8 output_meta;
 	u8 output_tuple;
@@ -106,7 +107,6 @@ struct {
 } print_skb_map SEC(".maps");
 #endif
 
-
 static __always_inline u32
 get_netns(struct sk_buff *skb) {
 	u32 netns = BPF_CORE_READ(skb, dev, nd_net.net, ns.inum);
@@ -128,6 +128,9 @@ filter_meta(struct sk_buff *skb) {
 			return false;
 	}
 	if (cfg->mark && BPF_CORE_READ(skb, mark) != cfg->mark) {
+		return false;
+	}
+	if (cfg->ifindex != 0 && BPF_CORE_READ(skb, dev, ifindex) != cfg->ifindex) {
 		return false;
 	}
 	return true;

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cloudflare/cbpfc v0.0.0-20221017140110-11acb56438a2
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/spf13/pflag v1.0.5
+	github.com/vishvananda/netns v0.0.4
 	golang.org/x/net v0.15.0
 	golang.org/x/sys v0.12.0
 	golang.org/x/tools v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -4,12 +4,24 @@
 
 package pwru
 
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
 // Version is the pwru version and is set at compile time via LDFLAGS-
 var Version string = "version unknown"
 
 type FilterCfg struct {
-	FilterNetns uint32
-	FilterMark  uint32
+	FilterNetns   uint32
+	FilterMark    uint32
+	FilterIfindex uint32
 
 	// TODO: if there are more options later, then you can consider using a bit map
 	OutputRelativeTS uint8
@@ -22,11 +34,10 @@ type FilterCfg struct {
 	TrackSkb byte
 }
 
-func GetConfig(flags *Flags) FilterCfg {
-	cfg := FilterCfg{
-		FilterNetns: flags.FilterNetns,
-		FilterMark:  flags.FilterMark,
-		IsSet:       1,
+func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
+	cfg = FilterCfg{
+		FilterMark: flags.FilterMark,
+		IsSet:      1,
 	}
 	if flags.OutputSkb {
 		cfg.OutputSkb = 1
@@ -40,10 +51,70 @@ func GetConfig(flags *Flags) FilterCfg {
 	if flags.OutputStack {
 		cfg.OutputStack = 1
 	}
-
 	if flags.FilterTrackSkb {
 		cfg.TrackSkb = 1
 	}
 
-	return cfg
+	netnsID, ns, err := parseNetns(flags.FilterNetns)
+	if err != nil {
+		return
+	}
+	if flags.FilterIfname != "" || flags.FilterNetns != "" {
+		cfg.FilterNetns = netnsID
+	}
+	if cfg.FilterIfindex, err = parseIfindex(flags.FilterIfname, ns); err != nil {
+		return
+	}
+	return
+}
+
+func parseNetns(netnsSpecifier string) (netnsID uint32, ns netns.NsHandle, err error) {
+	switch {
+	case netnsSpecifier == "":
+		ns, err = netns.Get()
+	case strings.HasPrefix(netnsSpecifier, "/"):
+		ns, err = netns.GetFromPath(netnsSpecifier)
+	case strings.HasPrefix(netnsSpecifier, "inode:"):
+		var netnsInode int
+		netnsInode, err = strconv.Atoi(netnsSpecifier[6:])
+		netnsID = uint32(netnsInode)
+	default:
+		err = fmt.Errorf("invalid netns specifier: %s", netnsSpecifier)
+	}
+	if ns == 0 || err != nil {
+		return
+	}
+	var s unix.Stat_t
+	if err = unix.Fstat(int(ns), &s); err != nil {
+		return
+	}
+	return uint32(s.Ino), ns, nil
+}
+
+func parseIfindex(ifname string, ns netns.NsHandle) (ifindex uint32, err error) {
+	if ifname == "" {
+		return
+	}
+	if ns == 0 {
+		return 0, fmt.Errorf("inode netns specifier cannot be used with --filter-ifname")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	currentNetns, err := netns.Get()
+	if err != nil {
+		return
+	}
+	defer netns.Set(currentNetns)
+
+	if err = netns.Set(ns); err != nil {
+		return
+	}
+
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return
+	}
+	return uint32(iface.Index), nil
 }

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -25,10 +25,11 @@ type Flags struct {
 
 	KernelBTF string
 
-	FilterNetns    uint32
+	FilterNetns    string
 	FilterMark     uint32
 	FilterFunc     string
 	FilterTrackSkb bool
+	FilterIfname   string
 	FilterPcap     string
 
 	OutputTS         string
@@ -53,15 +54,16 @@ func (f *Flags) SetFlags() {
 	flag.StringSliceVar(&f.KMods, "kmods", nil, "list of kernel modules names to attach to")
 	flag.BoolVar(&f.AllKMods, "all-kmods", false, "attach to all available kernel modules")
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
-	flag.Uint32Var(&f.FilterNetns, "filter-netns", 0, "filter netns inode")
+	flag.StringVar(&f.FilterNetns, "filter-netns", "", "filter netns (\"/proc/<pid>/ns/net\", \"inode:<inode>\")")
 	flag.Uint32Var(&f.FilterMark, "filter-mark", 0, "filter skb mark")
+	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
+	flag.StringVar(&f.FilterIfname, "filter-ifname", "", "filter skb ifname in --filter-netns (if not specified, use current netns)")
 	flag.StringVar(&f.OutputTS, "timestamp", "none", "print timestamp per skb (\"current\", \"relative\", \"absolute\", \"none\")")
 	flag.BoolVar(&f.OutputMeta, "output-meta", false, "print skb metadata")
 	flag.BoolVar(&f.OutputTuple, "output-tuple", false, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
-	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 
 	flag.StringVar(&f.OutputFile, "output-file", "", "write traces to file")
 

--- a/main.go
+++ b/main.go
@@ -132,8 +132,12 @@ func main() {
 		}
 	}
 
+	pwruConfig, err := pwru.GetConfig(&flags)
+	if err != nil {
+		log.Fatalf("Failed to get pwru config: %v", err)
+	}
 	if err := bpfSpec.RewriteConstants(map[string]interface{}{
-		"CFG": pwru.GetConfig(&flags),
+		"CFG": pwruConfig,
 	}); err != nil {
 		log.Fatalf("Failed to rewrite config: %v", err)
 	}

--- a/vendor/github.com/vishvananda/netns/.golangci.yml
+++ b/vendor/github.com/vishvananda/netns/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/vendor/github.com/vishvananda/netns/LICENSE
+++ b/vendor/github.com/vishvananda/netns/LICENSE
@@ -1,0 +1,192 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014 Vishvananda Ishaya.
+   Copyright 2014 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/vishvananda/netns/README.md
+++ b/vendor/github.com/vishvananda/netns/README.md
@@ -1,0 +1,51 @@
+# netns - network namespaces in go #
+
+The netns package provides an ultra-simple interface for handling
+network namespaces in go. Changing namespaces requires elevated
+privileges, so in most cases this code needs to be run as root.
+
+## Local Build and Test ##
+
+You can use go get command:
+
+    go get github.com/vishvananda/netns
+
+Testing (requires root):
+
+    sudo -E go test github.com/vishvananda/netns
+
+## Example ##
+
+```go
+package main
+
+import (
+    "fmt"
+    "net"
+    "runtime"
+
+    "github.com/vishvananda/netns"
+)
+
+func main() {
+    // Lock the OS Thread so we don't accidentally switch namespaces
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+
+    // Save the current network namespace
+    origns, _ := netns.Get()
+    defer origns.Close()
+
+    // Create a new network namespace
+    newns, _ := netns.New()
+    defer newns.Close()
+
+    // Do something with the network namespace
+    ifaces, _ := net.Interfaces()
+    fmt.Printf("Interfaces: %v\n", ifaces)
+
+    // Switch back to the original namespace
+    netns.Set(origns)
+}
+
+```

--- a/vendor/github.com/vishvananda/netns/doc.go
+++ b/vendor/github.com/vishvananda/netns/doc.go
@@ -1,0 +1,9 @@
+// Package netns allows ultra-simple network namespace handling. NsHandles
+// can be retrieved and set. Note that the current namespace is thread
+// local so actions that set and reset namespaces should use LockOSThread
+// to make sure the namespace doesn't change due to a goroutine switch.
+// It is best to close NsHandles when you are done with them. This can be
+// accomplished via a `defer ns.Close()` on the handle. Changing namespaces
+// requires elevated privileges, so in most cases this code needs to be run
+// as root.
+package netns

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -1,0 +1,283 @@
+package netns
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Deprecated: use golang.org/x/sys/unix pkg instead.
+const (
+	CLONE_NEWUTS  = unix.CLONE_NEWUTS  /* New utsname group? */
+	CLONE_NEWIPC  = unix.CLONE_NEWIPC  /* New ipcs */
+	CLONE_NEWUSER = unix.CLONE_NEWUSER /* New user namespace */
+	CLONE_NEWPID  = unix.CLONE_NEWPID  /* New pid namespace */
+	CLONE_NEWNET  = unix.CLONE_NEWNET  /* New network namespace */
+	CLONE_IO      = unix.CLONE_IO      /* Get io context */
+)
+
+const bindMountPath = "/run/netns" /* Bind mount path for named netns */
+
+// Setns sets namespace using golang.org/x/sys/unix.Setns.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
+func Setns(ns NsHandle, nstype int) (err error) {
+	return unix.Setns(int(ns), nstype)
+}
+
+// Set sets the current network namespace to the namespace represented
+// by NsHandle.
+func Set(ns NsHandle) (err error) {
+	return unix.Setns(int(ns), unix.CLONE_NEWNET)
+}
+
+// New creates a new network namespace, sets it as current and returns
+// a handle to it.
+func New() (ns NsHandle, err error) {
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		return -1, err
+	}
+	return Get()
+}
+
+// NewNamed creates a new named network namespace, sets it as current,
+// and returns a handle to it
+func NewNamed(name string) (NsHandle, error) {
+	if _, err := os.Stat(bindMountPath); os.IsNotExist(err) {
+		err = os.MkdirAll(bindMountPath, 0755)
+		if err != nil {
+			return None(), err
+		}
+	}
+
+	newNs, err := New()
+	if err != nil {
+		return None(), err
+	}
+
+	namedPath := path.Join(bindMountPath, name)
+
+	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0444)
+	if err != nil {
+		newNs.Close()
+		return None(), err
+	}
+	f.Close()
+
+	nsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+	err = unix.Mount(nsPath, namedPath, "bind", unix.MS_BIND, "")
+	if err != nil {
+		newNs.Close()
+		return None(), err
+	}
+
+	return newNs, nil
+}
+
+// DeleteNamed deletes a named network namespace
+func DeleteNamed(name string) error {
+	namedPath := path.Join(bindMountPath, name)
+
+	err := unix.Unmount(namedPath, unix.MNT_DETACH)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(namedPath)
+}
+
+// Get gets a handle to the current threads network namespace.
+func Get() (NsHandle, error) {
+	return GetFromThread(os.Getpid(), unix.Gettid())
+}
+
+// GetFromPath gets a handle to a network namespace
+// identified by the path
+func GetFromPath(path string) (NsHandle, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	return NsHandle(fd), nil
+}
+
+// GetFromName gets a handle to a named network namespace such as one
+// created by `ip netns add`.
+func GetFromName(name string) (NsHandle, error) {
+	return GetFromPath(filepath.Join(bindMountPath, name))
+}
+
+// GetFromPid gets a handle to the network namespace of a given pid.
+func GetFromPid(pid int) (NsHandle, error) {
+	return GetFromPath(fmt.Sprintf("/proc/%d/ns/net", pid))
+}
+
+// GetFromThread gets a handle to the network namespace of a given pid and tid.
+func GetFromThread(pid, tid int) (NsHandle, error) {
+	return GetFromPath(fmt.Sprintf("/proc/%d/task/%d/ns/net", pid, tid))
+}
+
+// GetFromDocker gets a handle to the network namespace of a docker container.
+// Id is prefixed matched against the running docker containers, so a short
+// identifier can be used as long as it isn't ambiguous.
+func GetFromDocker(id string) (NsHandle, error) {
+	pid, err := getPidForContainer(id)
+	if err != nil {
+		return -1, err
+	}
+	return GetFromPid(pid)
+}
+
+// borrowed from docker/utils/utils.go
+func findCgroupMountpoint(cgroupType string) (int, string, error) {
+	output, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return -1, "", err
+	}
+
+	// /proc/mounts has 6 fields per line, one mount per line, e.g.
+	// cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.Split(line, " ")
+		if len(parts) == 6 {
+			switch parts[2] {
+			case "cgroup2":
+				return 2, parts[1], nil
+			case "cgroup":
+				for _, opt := range strings.Split(parts[3], ",") {
+					if opt == cgroupType {
+						return 1, parts[1], nil
+					}
+				}
+			}
+		}
+	}
+
+	return -1, "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
+}
+
+// Returns the relative path to the cgroup docker is running in.
+// borrowed from docker/utils/utils.go
+// modified to get the docker pid instead of using /proc/self
+func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
+	if err != nil {
+		return "", err
+	}
+	result := strings.Split(string(dockerpid), "\n")
+	if len(result) == 0 || len(result[0]) == 0 {
+		return "", fmt.Errorf("docker pid not found in /var/run/docker.pid")
+	}
+	pid, err := strconv.Atoi(result[0])
+	if err != nil {
+		return "", err
+	}
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.Split(line, ":")
+		// any type used by docker should work
+		if (cgroupVer == 1 && parts[1] == cgroupType) ||
+			(cgroupVer == 2 && parts[1] == "") {
+			return parts[2], nil
+		}
+	}
+	return "", fmt.Errorf("cgroup '%s' not found in /proc/%d/cgroup", cgroupType, pid)
+}
+
+// Returns the first pid in a container.
+// borrowed from docker/utils/utils.go
+// modified to only return the first pid
+// modified to glob with id
+// modified to search for newer docker containers
+// modified to look for cgroups v2
+func getPidForContainer(id string) (int, error) {
+	pid := 0
+
+	// memory is chosen randomly, any cgroup used by docker works
+	cgroupType := "memory"
+
+	cgroupVer, cgroupRoot, err := findCgroupMountpoint(cgroupType)
+	if err != nil {
+		return pid, err
+	}
+
+	cgroupDocker, err := getDockerCgroup(cgroupVer, cgroupType)
+	if err != nil {
+		return pid, err
+	}
+
+	id += "*"
+
+	var pidFile string
+	if cgroupVer == 1 {
+		pidFile = "tasks"
+	} else if cgroupVer == 2 {
+		pidFile = "cgroup.procs"
+	} else {
+		return -1, fmt.Errorf("Invalid cgroup version '%d'", cgroupVer)
+	}
+
+	attempts := []string{
+		filepath.Join(cgroupRoot, cgroupDocker, id, pidFile),
+		// With more recent lxc versions use, cgroup will be in lxc/
+		filepath.Join(cgroupRoot, cgroupDocker, "lxc", id, pidFile),
+		// With more recent docker, cgroup will be in docker/
+		filepath.Join(cgroupRoot, cgroupDocker, "docker", id, pidFile),
+		// Even more recent docker versions under systemd use docker-<id>.scope/
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", pidFile),
+		// Even more recent docker versions under cgroup/systemd/docker/<id>/
+		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, pidFile),
+		// Kubernetes with docker and CNI is even more different. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "pod*", id, pidFile),
+		// Another flavor of containers location in recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
+		// When runs inside of a container with recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
+	}
+
+	var filename string
+	for _, attempt := range attempts {
+		filenames, _ := filepath.Glob(attempt)
+		if len(filenames) > 1 {
+			return pid, fmt.Errorf("Ambiguous id supplied: %v", filenames)
+		} else if len(filenames) == 1 {
+			filename = filenames[0]
+			break
+		}
+	}
+
+	if filename == "" {
+		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
+	}
+
+	output, err := os.ReadFile(filename)
+	if err != nil {
+		return pid, err
+	}
+
+	result := strings.Split(string(output), "\n")
+	if len(result) == 0 || len(result[0]) == 0 {
+		return pid, fmt.Errorf("No pid found for container")
+	}
+
+	pid, err = strconv.Atoi(result[0])
+	if err != nil {
+		return pid, fmt.Errorf("Invalid pid '%s': %s", result[0], err)
+	}
+
+	return pid, nil
+}

--- a/vendor/github.com/vishvananda/netns/netns_others.go
+++ b/vendor/github.com/vishvananda/netns/netns_others.go
@@ -1,0 +1,60 @@
+//go:build !linux
+// +build !linux
+
+package netns
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+// Setns sets namespace using golang.org/x/sys/unix.Setns on Linux. It
+// is not implemented on other platforms.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
+func Setns(ns NsHandle, nstype int) (err error) {
+	return ErrNotImplemented
+}
+
+func Set(ns NsHandle) (err error) {
+	return ErrNotImplemented
+}
+
+func New() (ns NsHandle, err error) {
+	return -1, ErrNotImplemented
+}
+
+func NewNamed(name string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func DeleteNamed(name string) error {
+	return ErrNotImplemented
+}
+
+func Get() (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromPath(path string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromName(name string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromPid(pid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromThread(pid, tid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromDocker(id string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}

--- a/vendor/github.com/vishvananda/netns/nshandle_linux.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_linux.go
@@ -1,0 +1,73 @@
+package netns
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// NsHandle is a handle to a network namespace. It can be cast directly
+// to an int and used as a file descriptor.
+type NsHandle int
+
+// Equal determines if two network handles refer to the same network
+// namespace. This is done by comparing the device and inode that the
+// file descriptors point to.
+func (ns NsHandle) Equal(other NsHandle) bool {
+	if ns == other {
+		return true
+	}
+	var s1, s2 unix.Stat_t
+	if err := unix.Fstat(int(ns), &s1); err != nil {
+		return false
+	}
+	if err := unix.Fstat(int(other), &s2); err != nil {
+		return false
+	}
+	return (s1.Dev == s2.Dev) && (s1.Ino == s2.Ino)
+}
+
+// String shows the file descriptor number and its dev and inode.
+func (ns NsHandle) String() string {
+	if ns == -1 {
+		return "NS(none)"
+	}
+	var s unix.Stat_t
+	if err := unix.Fstat(int(ns), &s); err != nil {
+		return fmt.Sprintf("NS(%d: unknown)", ns)
+	}
+	return fmt.Sprintf("NS(%d: %d, %d)", ns, s.Dev, s.Ino)
+}
+
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle.
+func (ns NsHandle) UniqueId() string {
+	if ns == -1 {
+		return "NS(none)"
+	}
+	var s unix.Stat_t
+	if err := unix.Fstat(int(ns), &s); err != nil {
+		return "NS(unknown)"
+	}
+	return fmt.Sprintf("NS(%d:%d)", s.Dev, s.Ino)
+}
+
+// IsOpen returns true if Close() has not been called.
+func (ns NsHandle) IsOpen() bool {
+	return ns != -1
+}
+
+// Close closes the NsHandle and resets its file descriptor to -1.
+// It is not safe to use an NsHandle after Close() is called.
+func (ns *NsHandle) Close() error {
+	if err := unix.Close(int(*ns)); err != nil {
+		return err
+	}
+	*ns = -1
+	return nil
+}
+
+// None gets an empty (closed) NsHandle.
+func None() NsHandle {
+	return NsHandle(-1)
+}

--- a/vendor/github.com/vishvananda/netns/nshandle_others.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_others.go
@@ -1,0 +1,45 @@
+//go:build !linux
+// +build !linux
+
+package netns
+
+// NsHandle is a handle to a network namespace. It can only be used on Linux,
+// but provides stub methods on other platforms.
+type NsHandle int
+
+// Equal determines if two network handles refer to the same network
+// namespace. It is only implemented on Linux.
+func (ns NsHandle) Equal(_ NsHandle) bool {
+	return false
+}
+
+// String shows the file descriptor number and its dev and inode.
+// It is only implemented on Linux, and returns "NS(none)" on other
+// platforms.
+func (ns NsHandle) String() string {
+	return "NS(none)"
+}
+
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle. It is only implemented on Linux,
+// and returns "NS(none)" on other platforms.
+func (ns NsHandle) UniqueId() string {
+	return "NS(none)"
+}
+
+// IsOpen returns true if Close() has not been called. It is only implemented
+// on Linux and always returns false on other platforms.
+func (ns NsHandle) IsOpen() bool {
+	return false
+}
+
+// Close closes the NsHandle and resets its file descriptor to -1.
+// It is only implemented on Linux.
+func (ns *NsHandle) Close() error {
+	return nil
+}
+
+// None gets an empty (closed) NsHandle.
+func None() NsHandle {
+	return NsHandle(-1)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -45,6 +45,9 @@ github.com/rivo/uniseg
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
+# github.com/vishvananda/netns v0.0.4
+## explicit; go 1.17
+github.com/vishvananda/netns
 # golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 ## explicit; go 1.18
 golang.org/x/exp/constraints


### PR DESCRIPTION
Set this flag to filter skb from/to the specific interface under the specific netns. If flag --filter-netns is not set, pwru uses current netns.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>