### PR TITLE
Support tracing tc-bpf

### DIFF
--- a/internal/pwru/bpf_prog.go
+++ b/internal/pwru/bpf_prog.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Leon Hwang.
+
+package pwru
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
+)
+
+func listBpfProgs(typ ebpf.ProgramType) ([]*ebpf.Program, error) {
+	var (
+		id  ebpf.ProgramID
+		err error
+	)
+
+	var progs []*ebpf.Program
+	for id, err = ebpf.ProgramGetNextID(id); err == nil; id, err = ebpf.ProgramGetNextID(id) {
+		prog, err := ebpf.NewProgramFromID(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if prog.Type() == typ {
+			progs = append(progs, prog)
+		} else {
+			_ = prog.Close()
+		}
+	}
+
+	if err != nil && !errors.Is(err, unix.ENOENT) {
+		return nil, err
+	}
+
+	return progs, nil
+}
+
+func getEntryFuncName(prog *ebpf.Program) (string, error) {
+	info, err := prog.Info()
+	if err != nil {
+		return "", fmt.Errorf("failed to get program info: %w", err)
+	}
+
+	id, ok := info.BTFID()
+	if !ok {
+		return "", fmt.Errorf("bpf program %s does not have BTF", info.Name)
+	}
+
+	handle, err := btf.NewHandleFromID(id)
+	if err != nil {
+		return "", fmt.Errorf("failed to get BTF handle: %w", err)
+	}
+	defer handle.Close()
+
+	spec, err := handle.Spec(nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get BTF spec: %w", err)
+	}
+
+	iter := spec.Iterate()
+	for iter.Next() {
+		if fn, ok := iter.Type.(*btf.Func); ok {
+			return fn.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no function found in %s bpf prog", info.Name)
+}
+
+func TraceTC(prevColl *ebpf.Collection, spec *ebpf.CollectionSpec,
+	opts *ebpf.CollectionOptions, outputSkb bool,
+) (func(), error) {
+	progs, err := listBpfProgs(ebpf.SchedCLS)
+	if err != nil {
+		log.Fatalf("Failed to list TC bpf progs: %v", err)
+	}
+
+	// Reusing maps from previous collection is to handle the events together
+	// with the kprobes.
+	replacedMaps := map[string]*ebpf.Map{
+		"events":          prevColl.Maps["events"],
+		"print_stack_map": prevColl.Maps["print_stack_map"],
+	}
+	if outputSkb {
+		replacedMaps["print_skb_map"] = prevColl.Maps["print_skb_map"]
+	}
+	opts.MapReplacements = replacedMaps
+
+	tracings := make([]link.Link, 0, len(progs))
+	for _, prog := range progs {
+		entryFn, err := getEntryFuncName(prog)
+		if err != nil {
+			log.Fatalf("Failed to get entry function name: %v", err)
+		}
+		spec := spec.Copy()
+		spec.Programs["fentry_tc"].AttachTarget = prog
+		spec.Programs["fentry_tc"].AttachTo = entryFn
+		coll, err := ebpf.NewCollectionWithOptions(spec, *opts)
+		if err != nil {
+			var (
+				ve          *ebpf.VerifierError
+				verifierLog string
+			)
+			if errors.As(err, &ve) {
+				verifierLog = fmt.Sprintf("Verifier error: %+v\n", ve)
+			}
+
+			log.Fatalf("Failed to load objects: %s\n%+v", verifierLog, err)
+		}
+		defer coll.Close()
+
+		tracing, err := link.AttachTracing(link.TracingOptions{
+			Program: coll.Programs["fentry_tc"],
+		})
+		if err != nil {
+			log.Fatalf("Failed to attach tracing: %v", err)
+		}
+		tracings = append(tracings, tracing)
+	}
+
+	return func() {
+		for _, tracing := range tracings {
+			_ = tracing.Close()
+		}
+		for _, prog := range progs {
+			_ = prog.Close()
+		}
+	}, nil
+}

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -28,6 +28,7 @@ type Flags struct {
 	FilterMark     uint32
 	FilterFunc     string
 	FilterTrackSkb bool
+	FilterTraceTc  bool
 	FilterIfname   string
 	FilterPcap     string
 
@@ -56,6 +57,7 @@ func (f *Flags) SetFlags() {
 	flag.StringVar(&f.FilterNetns, "filter-netns", "", "filter netns (\"/proc/<pid>/ns/net\", \"inode:<inode>\")")
 	flag.Uint32Var(&f.FilterMark, "filter-mark", 0, "filter skb mark")
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
+	flag.BoolVar(&f.FilterTraceTc, "filter-trace-tc", false, "trace TC bpf progs")
 	flag.StringVar(&f.FilterIfname, "filter-ifname", "", "filter skb ifname in --filter-netns (if not specified, use current netns)")
 	flag.StringVar(&f.OutputTS, "timestamp", "none", "print timestamp per skb (\"current\", \"relative\", \"absolute\", \"none\")")
 	flag.BoolVar(&f.OutputMeta, "output-meta", false, "print skb metadata")


### PR DESCRIPTION
This PR supports tracing tc-bpf as discussion in #239 .

Its running result likes:

```bash
#  ./pwru --output-limit-lines 10  --output-meta --output-tuple --filter-trace-tc --filter-func '.*udp' icmp
2023/10/21 15:22:05 Attaching kprobes (via kprobe-multi)...
1 / 1 [------------------------------------------------------------------------------------------------------------] 100.00% ? p/s
2023/10/21 15:22:05 Attached (ignored 0)
2023/10/21 15:22:05 Listening for events..
               SKB    CPU          PROCESS                     FUNC
0xffff940944c67900      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67c00      3           [pwru]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67e00      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff9408f1c97c00      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff9408f1c97600      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67700      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67b00      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67f00      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67400      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
0xffff940944c67900      3        [<empty>]                    dummy netns=4026531840 mark=0x0 iface=2(enp0s1) proto=0x0800 mtu=1500 len=98 192.168.64.1:0->192.168.64.2:0(icmp)
2023/10/21 15:22:08 Printed 10 events, exiting program..
```

