### PR TITLE
Find process using pid instead of tid

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -291,7 +291,7 @@ cont:
 		bpf_map_update_elem(&skb_addresses, &skb_addr, &TRUE, BPF_ANY);
 	}
 
-	event->pid = bpf_get_current_pid_tgid();
+	event->pid = bpf_get_current_pid_tgid() >> 32;
 	event->ts = bpf_ktime_get_ns();
 	event->cpu_id = bpf_get_smp_processor_id();
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -97,9 +97,9 @@ func (o *output) Print(event *Event) {
 		fmt.Fprintf(o.writer, "%12s ", time.Now().Format(absoluteTS))
 	}
 	p, err := ps.FindProcess(int(event.PID))
-	execName := "<empty>"
+	execName := fmt.Sprintf("<empty>(%d)", event.PID)
 	if err == nil && p != nil {
-		execName = p.Executable()
+		execName = fmt.Sprintf("%s(%d)", p.Executable(), event.PID)
 	}
 	ts := event.Timestamp
 	if o.flags.OutputTS == "relative" {


### PR DESCRIPTION
Previously we use tid to find process, leading to misleading output under some situations. 

According to documentation, `bpf_get_current_pid_tgid` returns `current->tgid << 32 | current->pid`. Kernel's view of the PID in user space is usually presented as the thread ID, and kernel's tgid in user space is seen as PID.