### PR TITLE
Makefile clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,6 @@ release:
 
 ## Build a new release
 local-release: clean
-	# TODO(brb) remove once https://github.com/cilium/pwru/issues/246 is resolved
-	clang --version
-	gcc --version
 	ARCHS='amd64 arm64' ./local-release.sh
 
 ## Install the GO Binary to the location specified by 'BINDIR'

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 	@echo ''
 	@echo 'Targets:'
 
-	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+	@awk '/^[a-zA-Z0-9_-]+:/ { \
 		helpMessage = match(lastLine, /^## (.*)/); \
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \


### PR DESCRIPTION
Minor clean-ups from taking a quick look at the Makefile:

- Makefile: Fix awk command in "make help"
- Makefile: Remove compiler versions for "make local-release"
