### PR TITLE
internal/pwru: Implement a proper help function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Usage: pwru [options] [pcap-filter]
       --filter-netns string       filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
       --filter-trace-tc           trace TC bpf progs
       --filter-track-skb          trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
+  -h, --help                      display this message and exit
       --kernel-btf string         specify kernel BTF file
       --kmods strings             list of kernel modules names to attach to
       --output-file string        write traces to file

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -21,6 +21,7 @@ const (
 
 type Flags struct {
 	ShowVersion bool
+	ShowHelp    bool
 
 	KernelBTF string
 
@@ -49,6 +50,7 @@ type Flags struct {
 }
 
 func (f *Flags) SetFlags() {
+	flag.BoolVarP(&f.ShowHelp, "help", "h", false, "display this message and exit")
 	flag.BoolVar(&f.ShowVersion, "version", false, "show pwru version and exit")
 	flag.StringVar(&f.KernelBTF, "kernel-btf", "", "specify kernel BTF file")
 	flag.StringSliceVar(&f.KMods, "kmods", nil, "list of kernel modules names to attach to")
@@ -80,6 +82,10 @@ func (f *Flags) SetFlags() {
 		fmt.Fprintf(os.Stderr, "    Available options:\n")
 		flag.PrintDefaults()
 	}
+}
+
+func (f *Flags) PrintHelp() {
+	flag.Usage()
 }
 
 func (f *Flags) Parse() {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,10 @@ func main() {
 	flags.SetFlags()
 	flags.Parse()
 
+	if flags.ShowHelp {
+		flags.PrintHelp()
+		os.Exit(0)
+	}
 	if flags.ShowVersion {
 		fmt.Printf("pwru %s\n", pwru.Version)
 		os.Exit(0)


### PR DESCRIPTION
With `./pwru --help` or `./pwru -h`, pwru:

  1. displays the help message,
  2. prints `pflag: help requested`,
  3. exits with error code 2.

Steps 2 and 3 are not expected, the interactive help should return 0 without displaying an error message. This is because of how `pflags.ParseAll()` works. From [its documentation][doc]: _The return value will be ErrHelp if -help was set but not defined._

Let's implement a dedicated function for displaying the help message (reusing `pflags.Usage()` and what we had in pwru already), and call it when users pass `--help` or `-h` to avoid this error and non-zero return value.

[doc]: https://pkg.go.dev/github.com/spf13/pflag#FlagSet.ParseAll
