### PR TITLE
Fix get_func_ip for --filter-trace-tc

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -15,6 +15,8 @@
 
 const static bool TRUE = true;
 
+volatile const static __u64 BPF_PROG_ADDR = 0;
+
 union addr {
 	u32 v4addr;
 	struct {
@@ -372,7 +374,7 @@ int BPF_PROG(fentry_tc, struct sk_buff *skb) {
 		return BPF_OK;
 
 	event.skb_addr = (u64) skb;
-	event.addr = bpf_get_func_ip(ctx);
+	event.addr = BPF_PROG_ADDR;
 	bpf_map_push_elem(&events, &event, BPF_EXIST);
 
 	return BPF_OK;

--- a/internal/pwru/bpf_prog.go
+++ b/internal/pwru/bpf_prog.go
@@ -100,6 +100,14 @@ func TraceTC(prevColl *ebpf.Collection, spec *ebpf.CollectionSpec,
 		if err != nil {
 			log.Fatalf("Failed to get entry function name: %v", err)
 		}
+
+		// The addr may hold the wrong rip value, because two addresses could
+		// have one same symbol. As discussed before, that doesn't affect the
+		// symbol resolution because even a "wrong" rip can be matched to the
+		// right symbol. However, this could make a difference when we want to
+		// distinguish which exact bpf prog is called.
+		//   -- @jschwinger233
+
 		addr, ok := name2addr[entryFn]
 		if !ok {
 			addr, ok = name2addr[name]

--- a/internal/pwru/bpf_prog.go
+++ b/internal/pwru/bpf_prog.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 Leon Hwang.
+/* Copyright Authors of Cilium */
 
 package pwru
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -130,16 +129,6 @@ func (o *output) Print(event *Event) {
 		funcName = ksym.name
 	} else {
 		funcName = fmt.Sprintf("0x%x", addr)
-	}
-
-	if strings.HasPrefix(funcName, "bpf_prog_") && strings.HasSuffix(funcName, "[bpf]") {
-		// The name of bpf prog is "bpf_prog_<id>_<name>  [bpf]". We want to
-		// print only the name.
-		items := strings.Split(funcName, "_")
-		if len(items) > 3 {
-			funcName = strings.Join(items[3:], "_")
-			funcName = strings.TrimSpace(funcName[:len(funcName)-5])
-		}
 	}
 
 	outFuncName := funcName

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 		log.Fatalf("Cannot find a matching kernel function")
 	}
 	// If --filter-trace-tc, it's to retrieve and print bpf prog's name.
-	addr2name, err := pwru.GetAddrs(funcs, flags.OutputStack ||
+	addr2name, name2addr, err := pwru.ParseKallsyms(funcs, flags.OutputStack ||
 		len(flags.KMods) != 0 || flags.FilterTraceTc)
 	if err != nil {
 		log.Fatalf("Failed to get function addrs: %s", err)
@@ -186,10 +186,7 @@ func main() {
 	defer coll.Close()
 
 	if flags.FilterTraceTc {
-		close, err := pwru.TraceTC(coll, bpfSpecFentry, &opts, flags.OutputSkb)
-		if err != nil {
-			log.Fatalf("Failed to trace TC: %v", err)
-		}
+		close := pwru.TraceTC(coll, bpfSpecFentry, &opts, flags.OutputSkb, name2addr)
 		defer close()
 	}
 


### PR DESCRIPTION
Fix #293 .

`bpf_get_func_ip()` is supported since 5.15 kernel.

- [bpf: Add bpf_get_func_ip helper for tracing programs](https://github.com/torvalds/linux/commit/9b99edcae5c80c8fb9f8e7149bae528c9e610a72)

As a result, we have to figure out a way to avoid `bpf_get_func_ip()`.

Then, I realise that something in `/proc/kallsyms` may help.

```bash
ffffffffc0024020 t bpf_prog_a04f5eef06a7f555_dummy	[bpf]
ffffffffc0024094 t bpf_prog_a04f5eef06a7f555_dummy	[bpf]
ffffffffc002ac4c t bpf_prog_0b3a2ce7164b50f3_fentry_tc	[bpf]
ffffffffc002add0 t bpf_prog_0ca2b1941f84fe9b_fexit_tc	[bpf]
```

Next, read the kernel source code.

- [bpf_prog_ksym_set_name()](https://github.com/torvalds/linux/blob/v5.8/kernel/bpf/core.c#L539)

So, the bpf prog info in `/proc/kallsyms` maybe formats with `ADDR t bpf_prog_<tag>_<name>\t[bpf]`.

Finally, I figure out the solution:

1. Record `tag` to `ADDR` in a map.
2. Get `tag` from bpf prog info.
3. Write `tag`'s `ADDR` to bpf code.

Great! And optimise the outputing name of bpf prog BTW.