### PR TITLE
Do kprobe.multi on addresses instead of symbols

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           test-name: basic-ipv4
           pwru-pcap-filter: 'dst host 1.0.0.1 and port 8080'
-          pwru-flags: --backend=kprobe
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.1/32 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.1:8080 || true
@@ -81,7 +80,6 @@ jobs:
         with:
           test-name: basic-ipv6
           pwru-pcap-filter: 'dst host 2606:4700:4700::1001 and port 8080'
-          pwru-flags: --backend=kprobe
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1001 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1001]:8080 || true
@@ -92,7 +90,6 @@ jobs:
         with:
           test-name: advanced-ipv4
           pwru-pcap-filter: 'tcp[tcpflags] = tcp-syn'
-          pwru-flags: --backend=kprobe
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.2/32 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.2:8080 || true
@@ -103,7 +100,6 @@ jobs:
         with:
           test-name: advanced-ipv6
           pwru-pcap-filter: 'ip6[53] & 0x3f = 0x2'
-          pwru-flags: --backend=kprobe
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1002 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1002]:8080 || true
@@ -114,7 +110,6 @@ jobs:
         with:
           test-name: pcap-filter-stack
           pwru-pcap-filter: '(((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)'
-          pwru-flags: --backend=kprobe
           traffic-setup: curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.1.1.1 || true
           expected-output-pattern: '1.1.1.1:80'
 
@@ -122,7 +117,7 @@ jobs:
         uses: ./.github/actions/pwru-test
         with:
           test-name: filter-track-skb
-          pwru-flags: --filter-track-skb --backend=kprobe
+          pwru-flags: --filter-track-skb
           pwru-pcap-filter: dst host 10.10.20.99
           traffic-setup: |
             iptables -t nat -I OUTPUT 1 -d 10.10.20.99/32 -j DNAT --to-destination 10.10.14.2
@@ -134,7 +129,6 @@ jobs:
         with:
           test-name: filter-arp
           pwru-pcap-filter: 'arp and arp[7] = 1 and arp[24]= 169 and arp[25] = 254 and arp[26] = 0 and arp[27] = 1'
-          pwru-flags: --backend=kprobe
           traffic-setup: |
             ip net a pwru
             ip l a pwru-veth type veth peer name pwru-veth-peer
@@ -153,7 +147,7 @@ jobs:
         uses: ./.github/actions/pwru-test
         with:
           test-name: filter-ifname
-          pwru-flags: --filter-ifname lo --backend=kprobe
+          pwru-flags: --filter-ifname lo
           pwru-pcap-filter: icmp
           traffic-setup: |
             ping -W1 -c1 127.0.0.1 || true

--- a/internal/pwru/ksym.go
+++ b/internal/pwru/ksym.go
@@ -22,6 +22,7 @@ func (a byAddr) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 type Addr2Name struct {
 	Addr2NameMap   map[uint64]*ksym
 	Addr2NameSlice []*ksym
+	Name2AddrMap   map[string][]uintptr
 }
 
 func (a *Addr2Name) findNearestSym(ip uint64) string {
@@ -44,6 +45,7 @@ func (a *Addr2Name) findNearestSym(ip uint64) string {
 func GetAddrs(funcs Funcs, all bool) (Addr2Name, error) {
 	a2n := Addr2Name{
 		Addr2NameMap: make(map[uint64]*ksym),
+		Name2AddrMap: make(map[string][]uintptr),
 	}
 
 	file, err := os.Open("/proc/kallsyms")
@@ -66,6 +68,7 @@ func GetAddrs(funcs Funcs, all bool) (Addr2Name, error) {
 				name: name,
 			}
 			a2n.Addr2NameMap[addr] = sym
+			a2n.Name2AddrMap[name] = append(a2n.Name2AddrMap[name], uintptr(addr))
 			if all {
 				a2n.Addr2NameSlice = append(a2n.Addr2NameSlice, sym)
 			}


### PR DESCRIPTION
Fix #284 
    
If we do kprobe.multi, kprobe on functions' addresses instead of symbols.