### PR TITLE
Makefile: add override possibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include override.mk
 GO := go
 GO_BUILD = CGO_ENABLED=1 $(GO) build
 GO_GENERATE = $(GO) generate


### PR DESCRIPTION
This commit adds a `include override.mk` statement that allows to safely override values when developing on arm64. Specifically these values are:
`override TARGET_GOARCH ?= arm64`
`override GOARCH ?= arm64`
`override LIBPCAP_ARCH ?= aarch64-unknown-linux-gnu`