### PR TITLE
Add actions: pwru-run, pwru-log

### DIFF
--- a/actions/pwru-log/action.yaml
+++ b/actions/pwru-log/action.yaml
@@ -1,0 +1,27 @@
+name: pwru-log
+description: 'Collect and upload pwru logs'
+inputs:
+  testname:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch PWRU logs
+      shell: bash
+      run: |
+        set -x
+
+        pods=$(kubectl get pods --selector name=pwru -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+        for pod in $pods; do
+          kubectl logs $pod
+          kubectl cp $pod:/tmp/pwru.log "$pod.${{ inputs.testname }}.log" || true
+        done
+
+    - name: Upload PWRU logs
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      with:
+        name: pwru-log
+        path: pwru*.log
+        retention-days: 5

--- a/actions/pwru-run/action.yaml
+++ b/actions/pwru-run/action.yaml
@@ -1,0 +1,113 @@
+name: pwru-k8s
+description: 'Run PWRU inside Kubernetes'
+inputs:
+  pwru-flags:
+    required: false
+    type: string
+  pwru-pcap-filter:
+    required: false
+    type: string
+  nodename:
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare workload yaml
+      shell: bash
+      run: |
+
+        if [[ -z "${{ inputs.nodename }}" ]]; then
+          # DaemonSet
+          cat >workload.yaml <<!
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: pwru
+        spec:
+          selector:
+            matchLabels:
+              name: pwru
+          template:
+            metadata:
+              labels:
+                name: pwru
+            spec:
+              containers:
+              - image: docker.io/cilium/pwru:latest
+                name: pwru
+                volumeMounts:
+                - mountPath: /sys/kernel/debug
+                  name: sys-kernel-debug
+                securityContext:
+                  privileged: true
+                command: ["/bin/sh"]
+                args: ["-c", "pwru --output-file /tmp/pwru.log --ready-file=/tmp/pwru.ready ${{ inputs.pwru-flags }} '${{ inputs.pwru-pcap-filter }}'"]
+                startupProbe:
+                  exec:
+                    command:
+                      - ls
+                      - /tmp/pwru.ready
+                  failureThreshold: 30
+                  periodSeconds: 10
+              volumes:
+              - name: sys-kernel-debug
+                hostPath:
+                  path: /sys/kernel/debug
+                  type: DirectoryOrCreate
+              hostNetwork: true
+              hostPID: true
+        !
+
+        else
+          # Pod
+          cat >workload.yaml <<!
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: pwru
+          labels:
+            name: pwru
+        spec:
+          nodeSelector:
+            kubernetes.io/hostname: ${{ inputs.nodename }}
+          containers:
+          - image: docker.io/cilium/pwru:latest
+            name: pwru
+            volumeMounts:
+            - mountPath: /sys/kernel/debug
+              name: sys-kernel-debug
+            securityContext:
+              privileged: true
+            command: ["/bin/sh"]
+            args: ["-c", "pwru --output-file /tmp/pwru.log --ready-file=/tmp/pwru.ready ${{ inputs.pwru-flags }} '${{ inputs.pwru-pcap-filter }}'"]
+            startupProbe:
+              exec:
+                command:
+                  - ls
+                  - /tmp/pwru.ready
+              failureThreshold: 30
+              periodSeconds: 10
+          volumes:
+          - name: sys-kernel-debug
+            hostPath:
+              path: /sys/kernel/debug
+              type: DirectoryOrCreate
+          hostNetwork: true
+          hostPID: true
+        !
+        fi
+
+        cat ./workload.yaml
+
+    - name: Deploy PWRU workload
+      shell: bash
+      run: |
+        kubectl apply -f ./workload.yaml
+
+        if [[ -z "${{ inputs.nodename }}" ]]; then
+          kubectl rollout status daemonset pwru --timeout=90s || (kubectl describe ds pwru; true)
+        else
+          kubectl wait pod pwru --for condition=Ready --timeout=90s || (kubectl describe po pwru; true)
+        fi


### PR DESCRIPTION
Other action running K8s can simply deploy PWRU and retrieve logs by:

```
uses: cilium/pwru/actions/pwru-run
with:
  pwru-flags: --output-meta --output-tuple --filter-track-skb
  pwru-pcap-filter: dst host 1.1.1.1 and dst port 53 and udp
  nodename: kind-worker # optional

...

uses: cilium/pwru/actions/pwru-log
if: ${{ !success() }}
with:
  testname: ${{ join(matrix.*, ',') }}
```

Example of pwru in pod: https://github.com/cilium/cilium/actions/runs/7408235602/job/20156042287
Example of pwru in daemonset: https://github.com/cilium/cilium/actions/runs/7407859278/job/20154878741