### PR TITLE
Remove unused relative timestamp config option

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -78,7 +78,6 @@ struct config {
 	u32 netns;
 	u32 mark;
 	u32 ifindex;
-	u8 output_timestamp;
 	u8 output_meta;
 	u8 output_tuple;
 	u8 output_skb;

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -24,11 +24,10 @@ type FilterCfg struct {
 	FilterIfindex uint32
 
 	// TODO: if there are more options later, then you can consider using a bit map
-	OutputRelativeTS uint8
-	OutputMeta       uint8
-	OutputTuple      uint8
-	OutputSkb        uint8
-	OutputStack      uint8
+	OutputMeta  uint8
+	OutputTuple uint8
+	OutputSkb   uint8
+	OutputStack uint8
 
 	IsSet    byte
 	TrackSkb byte


### PR DESCRIPTION
The option setting it was superseded by --timestamp=relative and is thus unused since commit 93fee0ade78d ("Make timestamp optional").