### PR TITLE
Let pwru work without /sys/kernel/debug/tracing/available_filter_functions

### DIFF
--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -189,3 +189,8 @@ func HaveBPFLinkTracing() bool {
 
 	return true
 }
+
+func HaveAvailableFilterFunctions() bool {
+	_, err := getAvailableFilterFunctions()
+	return err == nil
+}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	// has been backported to the stable, kprobe-multi cannot be used when attaching
 	// to kmods.
 	if flags.Backend == "" && len(flags.KMods) == 0 {
-		useKprobeMulti = pwru.HaveBPFLinkKprobeMulti()
+		useKprobeMulti = pwru.HaveBPFLinkKprobeMulti() && pwru.HaveAvailableFilterFunctions()
 	} else if flags.Backend == pwru.BackendKprobeMulti {
 		useKprobeMulti = true
 	}


### PR DESCRIPTION
/sys/kernel/debug/tracing/available_filter_functions is crucial for kprobe-multi but not necessary for kprobe, while pwru refuses to work without it.

This PR let pwru fallback to kprobe backend if /sys/kernel/debug/tracing/available_filter_functions is not available.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>