### PR TITLE
README.md: adjust kernel config table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ mount -t debugfs none /sys/kernel/debug
 
 The following kernel configuration is required.
 
-|           Option         |                         Note                         |
-| ------------------------ | ---------------------------------------------------- |
-| CONFIG_DEBUG_INFO_BTF=y  | available since >= 5.3                               |
-| CONFIG_KPROBES=y         |                                                      |
-| CONFIG_PERF_EVENTS=y     |                                                      |
-| CONFIG_BPF=y             |                                                      |
-| CONFIG_BPF_SYSCALL=y     |                                                      |
-| CONFIG_FUNCTION_TRACER=y | /sys/kernel/debug/tracing/available_filter_functions |
-| CONFIG_FPROBE=y          | --backend=kprobe-multi, available since >= 5.18      |
+|           Option         | Backend      |                   Note                               |
+| ------------------------ | ------------------------------------------------------------------- |
+| CONFIG_DEBUG_INFO_BTF=y  | both         | available since >= 5.3                               |
+| CONFIG_KPROBES=y         | both         |                                                      |
+| CONFIG_PERF_EVENTS=y     | both         |                                                      |
+| CONFIG_BPF=y             | both         |                                                      |
+| CONFIG_BPF_SYSCALL=y     | both         |                                                      |
+| CONFIG_FUNCTION_TRACER=y | kprobe-multi | /sys/kernel/debug/tracing/available_filter_functions |
+| CONFIG_FPROBE=y          | kprobe-multi | available since >= 5.18                              |
 
 You can use `zgrep $OPTION /proc/config.gz` to validate whether option is enabled.
 


### PR DESCRIPTION
After #309, CONFIG_FUNCTION_TRACER is only needed when using the kprobe-backend. Document this in the kernel config table and restructure it a bit while at it.