### PR TITLE
Change license of build.go to Apache-2

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"


### PR DESCRIPTION
Apache-2 has been used by all modules in the project.

Related: https://github.com/cilium/pwru/pull/190