### PR TITLE
chore: Show detaching progress always

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,19 +199,11 @@ func main() {
 
 	var kprobes []link.Link
 	defer func() {
-		var showProgressBar bool
-		select {
-		case <-ctx.Done():
-			showProgressBar = true
-
-		default:
-		}
-
-		batch := uint(1)
+		batch := uint(0)
 		if !useKprobeMulti {
 			batch = flags.FilterKprobeBatch
 		}
-		pwru.DetachKprobes(kprobes, showProgressBar, batch)
+		pwru.DetachKprobes(kprobes, batch)
 	}()
 
 	msg := "kprobe"


### PR DESCRIPTION
Fix the case that the detaching progress bar does not show when --output-limit-lines.