### PR TITLE
reduce the build context sent during a docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *.gif
 LICENSE
-README.md
+*.md
 *.png
+.git


### PR DESCRIPTION
Even though these files don't end up in the final image, they're unnecessary for the build image and don't need to be sent with the build context.