### PR TITLE
Implement --filter-track-skb-by-stackid

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,26 +52,29 @@ $ ./pwru --help
 Usage: pwru [options] [pcap-filter]
     Available pcap-filter: see "man 7 pcap-filter"
     Available options:
-      --all-kmods                 attach to all available kernel modules
-      --backend string            Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
-      --filter-func string        filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
-      --filter-ifname string      filter skb ifname in --filter-netns (if not specified, use current netns)
-      --filter-kprobe-batch uint  batch size for kprobe attaching/detaching (default 10)
-      --filter-mark uint32        filter skb mark
-      --filter-netns string       filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
-      --filter-trace-tc           trace TC bpf progs
-      --filter-track-skb          trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
-  -h, --help                      display this message and exit
-      --kernel-btf string         specify kernel BTF file
-      --kmods strings             list of kernel modules names to attach to
-      --output-file string        write traces to file
-      --output-limit-lines uint   exit the program after the number of events has been received/printed
-      --output-meta               print skb metadata
-      --output-skb                print skb
-      --output-stack              print stack
-      --output-tuple              print L4 tuple
-      --timestamp string          print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
-      --version                   show pwru version and exit
+      --all-kmods                     attach to all available kernel modules
+      --backend string                Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
+      --filter-func string            filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
+      --filter-ifname string          filter skb ifname in --filter-netns (if not specified, use current netns)
+      --filter-kprobe-batch uint      batch size for kprobe attaching/detaching (default 10)
+      --filter-mark uint32            filter skb mark
+      --filter-netns string           filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
+      --filter-trace-tc               trace TC bpf progs
+      --filter-track-skb              trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
+      --filter-track-skb-by-stackid   trace a packet even after it is kfreed (e.g., traffic going through bridge)
+  -h, --help                          display this message and exit
+      --kernel-btf string             specify kernel BTF file
+      --kmods strings                 list of kernel modules names to attach to
+      --output-file string            write traces to file
+      --output-json                   output traces in JSON format
+      --output-limit-lines uint       exit the program after the number of events has been received/printed
+      --output-meta                   print skb metadata
+      --output-skb                    print skb
+      --output-stack                  print stack
+      --output-tuple                  print L4 tuple
+      --timestamp string              print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
+      --version                       show pwru version and exit
+
 ```
 
 The `--filter-func` switch does an exact match on function names i.e.

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -29,8 +29,9 @@ type FilterCfg struct {
 	OutputSkb   uint8
 	OutputStack uint8
 
-	IsSet    byte
-	TrackSkb byte
+	IsSet             byte
+	TrackSkb          byte
+	TrackSkbByStackid byte
 }
 
 func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
@@ -52,6 +53,9 @@ func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	}
 	if flags.FilterTrackSkb {
 		cfg.TrackSkb = 1
+	}
+	if flags.FilterTrackSkbByStackid {
+		cfg.TrackSkbByStackid = 1
 	}
 
 	netnsID, ns, err := parseNetns(flags.FilterNetns)

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -25,14 +25,15 @@ type Flags struct {
 
 	KernelBTF string
 
-	FilterNetns       string
-	FilterMark        uint32
-	FilterFunc        string
-	FilterTrackSkb    bool
-	FilterTraceTc     bool
-	FilterIfname      string
-	FilterPcap        string
-	FilterKprobeBatch uint
+	FilterNetns             string
+	FilterMark              uint32
+	FilterFunc              string
+	FilterTrackSkb          bool
+	FilterTrackSkbByStackid bool
+	FilterTraceTc           bool
+	FilterIfname            string
+	FilterPcap              string
+	FilterKprobeBatch       uint
 
 	OutputTS         string
 	OutputMeta       bool
@@ -61,6 +62,7 @@ func (f *Flags) SetFlags() {
 	flag.StringVar(&f.FilterNetns, "filter-netns", "", "filter netns (\"/proc/<pid>/ns/net\", \"inode:<inode>\")")
 	flag.Uint32Var(&f.FilterMark, "filter-mark", 0, "filter skb mark")
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
+	flag.BoolVar(&f.FilterTrackSkbByStackid, "filter-track-skb-by-stackid", false, "trace a packet even after it is kfreed (e.g., traffic going through bridge)")
 	flag.BoolVar(&f.FilterTraceTc, "filter-trace-tc", false, "trace TC bpf progs")
 	flag.StringVar(&f.FilterIfname, "filter-ifname", "", "filter skb ifname in --filter-netns (if not specified, use current netns)")
 	flag.UintVar(&f.FilterKprobeBatch, "filter-kprobe-batch", 10, "batch size for kprobe attaching/detaching")

--- a/main.go
+++ b/main.go
@@ -169,11 +169,11 @@ func main() {
 
 	// If not tracking skb, deleting the skb-tracking programs to reduce loading
 	// time.
-	if !flags.FilterTrackSkb {
+	if !flags.FilterTrackSkb && !flags.FilterTrackSkbByStackid {
 		delete(bpfSpec.Programs, "kprobe_skb_lifetime_termination")
 	}
 
-	if !flags.FilterTrackSkb || !haveFexit {
+	if (!flags.FilterTrackSkb && !flags.FilterTrackSkbByStackid) || !haveFexit {
 		delete(bpfSpec.Programs, "fexit_skb_clone")
 		delete(bpfSpec.Programs, "fexit_skb_copy")
 	}
@@ -214,7 +214,7 @@ func main() {
 	ignored := 0
 	bar := pb.StartNew(len(funcs))
 
-	if flags.FilterTrackSkb {
+	if flags.FilterTrackSkb || flags.FilterTrackSkbByStackid {
 		kp, err := link.Kprobe("kfree_skbmem", coll.Programs["kprobe_skb_lifetime_termination"], nil)
 		bar.Increment()
 		if err != nil {


### PR DESCRIPTION
This PR adds `--filter-track-skb-by-stackid` so we can track traffic even the skb is kfreed and re-built, which frequently happens when traffic is going through bridge. This is more powerful than `--filter-track-skb` on the scenario of encryption + encapsulation.

This PR also paves the way for "tailcall tracing" which relies on stack unwinding. I find it valuable to make stack unwinding a general feature so this is it.

An skb can have different stacks during its lifetime, this PR tries to handle it carefully by comparing `old_stackid` with `stackid` and updating the bpf map in time.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>