### PR TITLE
Implement --filter-non-skb-funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,29 @@ $ ./pwru --help
 Usage: pwru [options] [pcap-filter]
     Available pcap-filter: see "man 7 pcap-filter"
     Available options:
-      --all-kmods                     attach to all available kernel modules
-      --backend string                Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
-      --filter-func string            filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
-      --filter-ifname string          filter skb ifname in --filter-netns (if not specified, use current netns)
-      --filter-kprobe-batch uint      batch size for kprobe attaching/detaching (default 10)
-      --filter-mark uint32            filter skb mark
-      --filter-netns string           filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
-      --filter-trace-tc               trace TC bpf progs
-      --filter-track-skb              trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
-      --filter-track-skb-by-stackid   trace a packet even after it is kfreed (e.g., traffic going through bridge)
-  -h, --help                          display this message and exit
-      --kernel-btf string             specify kernel BTF file
-      --kmods strings                 list of kernel modules names to attach to
-      --output-file string            write traces to file
-      --output-json                   output traces in JSON format
-      --output-limit-lines uint       exit the program after the number of events has been received/printed
-      --output-meta                   print skb metadata
-      --output-skb                    print skb
-      --output-stack                  print stack
-      --output-tuple                  print L4 tuple
-      --timestamp string              print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
-      --version                       show pwru version and exit
-
+      --all-kmods                      attach to all available kernel modules
+      --backend string                 Tracing backend('kprobe', 'kprobe-multi'). Will auto-detect if not specified.
+      --filter-func string             filter kernel functions to be probed by name (exact match, supports RE2 regular expression)
+      --filter-ifname string           filter skb ifname in --filter-netns (if not specified, use current netns)
+      --filter-kprobe-batch uint       batch size for kprobe attaching/detaching (default 10)
+      --filter-mark uint32             filter skb mark
+      --filter-netns string            filter netns ("/proc/<pid>/ns/net", "inode:<inode>")
+      --filter-non-skb-funcs strings   filter non-skb kernel functions to be probed (--filter-track-skb-by-stackid will be enabled)
+      --filter-trace-tc                trace TC bpf progs
+      --filter-track-skb               trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)
+      --filter-track-skb-by-stackid    trace a packet even after it is kfreed (e.g., traffic going through bridge)
+  -h, --help                           display this message and exit
+      --kernel-btf string              specify kernel BTF file
+      --kmods strings                  list of kernel modules names to attach to
+      --output-file string             write traces to file
+      --output-json                    output traces in JSON format
+      --output-limit-lines uint        exit the program after the number of events has been received/printed
+      --output-meta                    print skb metadata
+      --output-skb                     print skb
+      --output-stack                   print stack
+      --output-tuple                   print L4 tuple
+      --timestamp string               print timestamp per skb ("current", "relative", "absolute", "none") (default "none")
+      --version                        show pwru version and exit
 ```
 
 The `--filter-func` switch does an exact match on function names i.e.

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -28,6 +28,7 @@ type Flags struct {
 	FilterNetns             string
 	FilterMark              uint32
 	FilterFunc              string
+	FilterNonSkbFuncs       []string
 	FilterTrackSkb          bool
 	FilterTrackSkbByStackid bool
 	FilterTraceTc           bool
@@ -59,6 +60,7 @@ func (f *Flags) SetFlags() {
 	flag.StringSliceVar(&f.KMods, "kmods", nil, "list of kernel modules names to attach to")
 	flag.BoolVar(&f.AllKMods, "all-kmods", false, "attach to all available kernel modules")
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
+	flag.StringSliceVar(&f.FilterNonSkbFuncs, "filter-non-skb-funcs", nil, "filter non-skb kernel functions to be probed (--filter-track-skb-by-stackid will be enabled)")
 	flag.StringVar(&f.FilterNetns, "filter-netns", "", "filter netns (\"/proc/<pid>/ns/net\", \"inode:<inode>\")")
 	flag.Uint32Var(&f.FilterMark, "filter-mark", 0, "filter skb mark")
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
@@ -98,6 +100,9 @@ func (f *Flags) PrintHelp() {
 func (f *Flags) Parse() {
 	flag.Parse()
 	f.FilterPcap = strings.Join(flag.Args(), " ")
+	if len(f.FilterNonSkbFuncs) > 0 {
+		f.FilterTrackSkbByStackid = true
+	}
 }
 
 type Tuple struct {


### PR DESCRIPTION
By enabling --filter-track-skb-by-stackid, we can track kernel functions without skb parameter. 

For example, to observe xfrm state lookup, we can use command: `pwru --filter-non-skb-funcs xfrm_state_look_at,xfrm_state_lookup,xfrm_state_lookup_byaddr,xfrm_state_lookup_byspi`. 

Also, this is another step towards "tailcall tracing". This PR allows us to attach bpf helpers (that are probably not skb functions). By fetching bpf helpers' caller pc and converting pc into symbol, we'll see the bpf prog name.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>