### PR TITLE
Add support for printing skb_shared_info

### DIFF
--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -24,10 +24,11 @@ type FilterCfg struct {
 	FilterIfindex uint32
 
 	// TODO: if there are more options later, then you can consider using a bit map
-	OutputMeta  uint8
-	OutputTuple uint8
-	OutputSkb   uint8
-	OutputStack uint8
+	OutputMeta   uint8
+	OutputTuple  uint8
+	OutputSkb    uint8
+	OutputShinfo uint8
+	OutputStack  uint8
 
 	IsSet             byte
 	TrackSkb          byte
@@ -41,6 +42,9 @@ func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	}
 	if flags.OutputSkb {
 		cfg.OutputSkb = 1
+	}
+	if flags.OutputShinfo {
+		cfg.OutputShinfo = 1
 	}
 	if flags.OutputMeta {
 		cfg.OutputMeta = 1

--- a/internal/pwru/tc_tracer.go
+++ b/internal/pwru/tc_tracer.go
@@ -94,7 +94,7 @@ func (t *tcTracer) trace(spec *ebpf.CollectionSpec,
 }
 
 func TraceTC(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
-	opts *ebpf.CollectionOptions, outputSkb bool, n2a BpfProgName2Addr,
+	opts *ebpf.CollectionOptions, outputSkb bool, outputShinfo bool, n2a BpfProgName2Addr,
 ) func() {
 	progs, err := listBpfProgs(ebpf.SchedCLS)
 	if err != nil {
@@ -109,6 +109,9 @@ func TraceTC(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
 	}
 	if outputSkb {
 		replacedMaps["print_skb_map"] = coll.Maps["print_skb_map"]
+	}
+	if outputShinfo {
+		replacedMaps["print_shinfo_map"] = coll.Maps["print_shinfo_map"]
 	}
 	opts.MapReplacements = replacedMaps
 

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -41,6 +41,7 @@ type Flags struct {
 	OutputMeta       bool
 	OutputTuple      bool
 	OutputSkb        bool
+	OutputShinfo     bool
 	OutputStack      bool
 	OutputLimitLines uint64
 	OutputFile       string
@@ -73,6 +74,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputMeta, "output-meta", false, "print skb metadata")
 	flag.BoolVar(&f.OutputTuple, "output-tuple", false, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
+	flag.BoolVar(&f.OutputShinfo, "output-skb-shared-info", false, "print skb shared info")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
 
@@ -133,15 +135,16 @@ type StackData struct {
 }
 
 type Event struct {
-	PID          uint32
-	Type         uint32
-	Addr         uint64
-	SAddr        uint64
-	Timestamp    uint64
-	PrintSkbId   uint64
-	Meta         Meta
-	Tuple        Tuple
-	PrintStackId int64
-	ParamSecond  uint64
-	CPU          uint32
+	PID           uint32
+	Type          uint32
+	Addr          uint64
+	SAddr         uint64
+	Timestamp     uint64
+	PrintSkbId    uint64
+	PrintShinfoId uint64
+	Meta          Meta
+	Tuple         Tuple
+	PrintStackId  int64
+	ParamSecond   uint64
+	CPU           uint32
 }

--- a/main.go
+++ b/main.go
@@ -111,9 +111,9 @@ func main() {
 
 	var bpfSpec *ebpf.CollectionSpec
 	switch {
-	case flags.OutputSkb && useKprobeMulti:
+	case (flags.OutputSkb || flags.OutputShinfo) && useKprobeMulti:
 		bpfSpec, err = LoadKProbeMultiPWRU()
-	case flags.OutputSkb:
+	case flags.OutputSkb || flags.OutputShinfo:
 		bpfSpec, err = LoadKProbePWRU()
 	case useKprobeMulti:
 		bpfSpec, err = LoadKProbeMultiPWRUWithoutOutputSKB()
@@ -193,7 +193,7 @@ func main() {
 	defer coll.Close()
 
 	if flags.FilterTraceTc {
-		close := pwru.TraceTC(coll, bpfSpecFentry, &opts, flags.OutputSkb, name2addr)
+		close := pwru.TraceTC(coll, bpfSpecFentry, &opts, flags.OutputSkb, flags.OutputShinfo, name2addr)
 		defer close()
 	}
 
@@ -304,8 +304,9 @@ func main() {
 	}
 
 	printSkbMap := coll.Maps["print_skb_map"]
+	printShinfoMap := coll.Maps["print_shinfo_map"]
 	printStackMap := coll.Maps["print_stack_map"]
-	output, err := pwru.NewOutput(&flags, printSkbMap, printStackMap, addr2name, useKprobeMulti, btfSpec)
+	output, err := pwru.NewOutput(&flags, printSkbMap, printShinfoMap, printStackMap, addr2name, useKprobeMulti, btfSpec)
 	if err != nil {
 		log.Fatalf("Failed to create outputer: %s", err)
 	}


### PR DESCRIPTION
struct skb_shared_info is a structure that primarily used by GSO/GRO to store metadata. It is useful to track the behavior of the segmentation offload behavior.

Example output:

```
0xffff985c8384bb00      5 [irq/215-iwlwifi:queue_7:458]        validate_xmit_skb
(struct skb_shared_info){
 .gso_segs = (short unsigned int)1,
 .gso_type = (unsigned int)1,
 .dataref = (atomic_t){
  .counter = (int)65538,
 },
}
```