### PR TITLE
Implement pwru --output-caller to print caller function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Usage: pwru [options] [pcap-filter]
   -h, --help                           display this message and exit
       --kernel-btf string              specify kernel BTF file
       --kmods strings                  list of kernel modules names to attach to
+      --output-caller                  print caller function name
       --output-file string             write traces to file
       --output-json                    output traces in JSON format
       --output-limit-lines uint        exit the program after the number of events has been received/printed

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -102,7 +102,8 @@ struct config {
 	u8 output_skb: 1;
 	u8 output_shinfo: 1;
 	u8 output_stack: 1;
-	u8 output_unused: 3;
+	u8 output_caller: 1;
+	u8 output_unused: 2;
 	u8 is_set: 1;
 	u8 track_skb: 1;
 	u8 track_skb_by_stackid: 1;

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -53,6 +53,7 @@ struct event_t {
 	u32 pid;
 	u32 type;
 	u64 addr;
+	u64 caller_addr;
 	u64 skb_addr;
 	u64 ts;
 	typeof(print_skb_id) print_skb_id;
@@ -429,6 +430,9 @@ kprobe_skb(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip, u64 *
 	event.skb_addr = (u64) skb;
 	event.addr = has_get_func_ip ? bpf_get_func_ip(ctx) : PT_REGS_IP(ctx);
 	event.param_second = PT_REGS_PARM2(ctx);
+	if (CFG.output_caller)
+		bpf_probe_read_kernel(&event.caller_addr, sizeof(event.caller_addr), (void *)PT_REGS_SP(ctx));
+
 	bpf_map_push_elem(&events, &event, BPF_EXIST);
 
 	return BPF_OK;

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -97,14 +97,16 @@ struct config {
 	u32 netns;
 	u32 mark;
 	u32 ifindex;
-	u8 output_meta;
-	u8 output_tuple;
-	u8 output_skb;
-	u8 output_shinfo;
-	u8 output_stack;
-	u8 is_set;
-	u8 track_skb;
-	u8 track_skb_by_stackid;
+	u8 output_meta: 1;
+	u8 output_tuple: 1;
+	u8 output_skb: 1;
+	u8 output_shinfo: 1;
+	u8 output_stack: 1;
+	u8 output_unused: 3;
+	u8 is_set: 1;
+	u8 track_skb: 1;
+	u8 track_skb_by_stackid: 1;
+	u8 unused: 5;
 } __attribute__((packed));
 
 static volatile const struct config CFG;

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -21,6 +21,7 @@ const (
 	OutputSkbMask
 	OutputShinfoMask
 	OutputStackMask
+	OutputCallerMask
 )
 
 const (
@@ -60,6 +61,9 @@ func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	}
 	if flags.OutputStack {
 		cfg.OutputFlags |= OutputStackMask
+	}
+	if flags.OutputCaller {
+		cfg.OutputFlags |= OutputCallerMask
 	}
 	if flags.FilterTrackSkb {
 		cfg.FilterFlags |= TrackSkbMask

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -15,6 +15,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	OutputMetaMask uint8 = 1 << iota
+	OutputTupleMask
+	OutputSkbMask
+	OutputShinfoMask
+	OutputStackMask
+)
+
+const (
+	IsSetMask uint8 = 1 << iota
+	TrackSkbMask
+	TrackSkbByStackidMask
+)
+
 // Version is the pwru version and is set at compile time via LDFLAGS-
 var Version string = "version unknown"
 
@@ -23,43 +37,35 @@ type FilterCfg struct {
 	FilterMark    uint32
 	FilterIfindex uint32
 
-	// TODO: if there are more options later, then you can consider using a bit map
-	OutputMeta   uint8
-	OutputTuple  uint8
-	OutputSkb    uint8
-	OutputShinfo uint8
-	OutputStack  uint8
-
-	IsSet             byte
-	TrackSkb          byte
-	TrackSkbByStackid byte
+	OutputFlags uint8
+	FilterFlags uint8
 }
 
 func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	cfg = FilterCfg{
 		FilterMark: flags.FilterMark,
-		IsSet:      1,
 	}
+	cfg.FilterFlags |= IsSetMask
 	if flags.OutputSkb {
-		cfg.OutputSkb = 1
+		cfg.OutputFlags |= OutputSkbMask
 	}
 	if flags.OutputShinfo {
-		cfg.OutputShinfo = 1
+		cfg.OutputFlags |= OutputShinfoMask
 	}
 	if flags.OutputMeta {
-		cfg.OutputMeta = 1
+		cfg.OutputFlags |= OutputMetaMask
 	}
 	if flags.OutputTuple {
-		cfg.OutputTuple = 1
+		cfg.OutputFlags |= OutputTupleMask
 	}
 	if flags.OutputStack {
-		cfg.OutputStack = 1
+		cfg.OutputFlags |= OutputStackMask
 	}
 	if flags.FilterTrackSkb {
-		cfg.TrackSkb = 1
+		cfg.FilterFlags |= TrackSkbMask
 	}
 	if flags.FilterTrackSkbByStackid {
-		cfg.TrackSkbByStackid = 1
+		cfg.FilterFlags |= TrackSkbByStackidMask
 	}
 
 	netnsID, ns, err := parseNetns(flags.FilterNetns)

--- a/internal/pwru/ksym.go
+++ b/internal/pwru/ksym.go
@@ -32,14 +32,14 @@ func (a *Addr2Name) findNearestSym(ip uint64) string {
 		h := int(uint(i+j) >> 1)
 		if a.Addr2NameSlice[h].addr <= ip {
 			if h+1 < total && a.Addr2NameSlice[h+1].addr > ip {
-				return a.Addr2NameSlice[h].name
+				return strings.Replace(a.Addr2NameSlice[h].name, "\t", "", -1)
 			}
 			i = h + 1
 		} else {
 			j = h
 		}
 	}
-	return a.Addr2NameSlice[i-1].name
+	return strings.Replace(a.Addr2NameSlice[i-1].name, "\t", "", -1)
 }
 
 func ParseKallsyms(funcs Funcs, all bool) (Addr2Name, BpfProgName2Addr, error) {

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -140,6 +140,7 @@ type Event struct {
 	PID           uint32
 	Type          uint32
 	Addr          uint64
+	CallerAddr    uint64
 	SAddr         uint64
 	Timestamp     uint64
 	PrintSkbId    uint64

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -43,6 +43,7 @@ type Flags struct {
 	OutputSkb        bool
 	OutputShinfo     bool
 	OutputStack      bool
+	OutputCaller     bool
 	OutputLimitLines uint64
 	OutputFile       string
 	OutputJson       bool
@@ -76,6 +77,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputShinfo, "output-skb-shared-info", false, "print skb shared info")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
+	flag.BoolVar(&f.OutputCaller, "output-caller", false, "print caller function name")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
 
 	flag.StringVar(&f.OutputFile, "output-file", "", "write traces to file")

--- a/main.go
+++ b/main.go
@@ -99,7 +99,8 @@ func main() {
 	}
 	// If --filter-trace-tc, it's to retrieve and print bpf prog's name.
 	addr2name, name2addr, err := pwru.ParseKallsyms(funcs, flags.OutputStack ||
-		len(flags.KMods) != 0 || flags.FilterTraceTc || len(flags.FilterNonSkbFuncs) > 0)
+		len(flags.KMods) != 0 || flags.FilterTraceTc || len(flags.FilterNonSkbFuncs) > 0 ||
+		flags.OutputCaller)
 	if err != nil {
 		log.Fatalf("Failed to get function addrs: %s", err)
 	}


### PR DESCRIPTION
The example output of `pwru --output-caller  --output-meta --output-tuple --filter-track-skb 'dst host 1.1.1.1 and port 80 ' `:

```
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC CALLER
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0               0         0x0000 0     60    10.103.80.168:55476->1.1.1.1:80(tcp) ip_local_out __ip_queue_xmit
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0               0         0x0000 0     60    10.103.80.168:55476->1.1.1.1:80(tcp) __ip_local_out ip_local_out
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0               0         0x0800 0     60    10.103.80.168:55476->1.1.1.1:80(tcp) nf_hook_slow   __ip_local_out
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0               0         0x0800 0     60    10.103.80.168:55476->1.1.1.1:80(tcp) ip_output      ip_local_out
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  60    10.103.80.168:55476->1.1.1.1:80(tcp) nf_hook_slow   ip_output
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  60    10.103.80.168:55476->1.1.1.1:80(tcp) apparmor_ip_postroute nf_hook_slow
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  60    10.103.80.168:55476->1.1.1.1:80(tcp) ip_finish_output      ip_output
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  60    10.103.80.168:55476->1.1.1.1:80(tcp) __ip_finish_output    ip_finish_output
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  60    10.103.80.168:55476->1.1.1.1:80(tcp) ip_finish_output2     __ip_finish_output
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) __dev_queue_xmit      neigh_hh_output
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) qdisc_pkt_len_init    __dev_queue_xmit
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) netdev_core_pick_tx   __dev_queue_xmit
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) validate_xmit_skb     __dev_queue_xmit
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) netif_skb_features    validate_xmit_skb
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) skb_network_protocol  netif_skb_features
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) skb_csum_hwoffload_help validate_xmit_skb
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) validate_xmit_xfrm      validate_xmit_skb
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) dev_hard_start_xmit     __dev_queue_xmit
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) skb_csum_hwoffload_help ieee80211_tx_skb_fixup[mac80211]
0xffff918922e634e8 3   ~bin/curl:659155 4026531840 0          wlp0s20f3:2    0x0800 1500  74    10.103.80.168:55476->1.1.1.1:80(tcp) skb_push                __ieee80211_xmit_fast[mac80211]
0xffff918922e634e8 7   ~ault_queue:1095 4026531840 0          wlp0s20f3:2    0x0800 1500  94    10.103.80.168:55476->1.1.1.1:80(tcp) tcp_wfree               __ieee80211_tx_status[mac80211]
0xffff918922e634e8 7   ~ault_queue:1095 4026531840 0          wlp0s20f3:2    0x0800 1500  94    10.103.80.168:55476->1.1.1.1:80(tcp) consume_skb             __ieee80211_tx_status[mac80211]
0xffff918922e634e8 7   ~ault_queue:1095 4026531840 0          wlp0s20f3:2    0x0800 1500  94    10.103.80.168:55476->1.1.1.1:80(tcp) skb_release_head_state  consume_skb
0xffff918922e634e8 7   ~ault_queue:1095 4026531840 0          wlp0s20f3:2    0x0800 1500  94    10.103.80.168:55476->1.1.1.1:80(tcp) skb_release_data        consume_skb
0xffff918922e634e8 7   ~ault_queue:1095 4026531840 0          wlp0s20f3:2    0x0800 1500  94    10.103.80.168:55476->1.1.1.1:80(tcp) kfree_skbmem            consume_skb
```