### PR TITLE
gh/workflows: Fix fetching pwru logs

### DIFF
--- a/.github/actions/pwru-test/action.yaml
+++ b/.github/actions/pwru-test/action.yaml
@@ -45,9 +45,18 @@ runs:
 
           grep -P '${{ inputs.expected-output-pattern }}' /tmp/pwru-${{ inputs.test-name }}.log
 
+    - name: Fetch artifacts from LVH VM
+      if: ${{ !success() }}
+      uses: cilium/little-vm-helper@9d758b756305e83718a51b792a5aeabd022a39ec # v0.0.16
+      with:
+        provision: 'false'
+        cmd: |
+          mkdir -p /host/logs/${{ inputs.test-name }}
+          cp /tmp/pwru-* /host/logs/${{ inputs.test-name }}
+
     - name: Upload artifacts
       if: ${{ !success() }}
       uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
       with:
         name: logs-${{ inputs.test-name }}
-        path: /tmp/pwru-*
+        path: ./logs/${{ inputs.test-name }}/pwru-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Test basic IPv4
         uses: ./.github/actions/pwru-test
         with:
-          test-name: basic-ipv4
+          test-name: ${{ matrix.kernel }}-basic-ipv4
           pwru-pcap-filter: 'dst host 1.0.0.1 and port 8080'
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.1/32 --dport 8080 -j DROP
@@ -77,7 +77,7 @@ jobs:
       - name: Test basic IPv6
         uses: ./.github/actions/pwru-test
         with:
-          test-name: basic-ipv6
+          test-name: ${{ matrix.kernel }}-basic-ipv6
           pwru-pcap-filter: 'dst host 2606:4700:4700::1001 and port 8080'
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1001 --dport 8080 -j DROP
@@ -87,7 +87,7 @@ jobs:
       - name: Test advanced IPv4
         uses: ./.github/actions/pwru-test
         with:
-          test-name: advanced-ipv4
+          test-name: ${{ matrix.kernel }}-advanced-ipv4
           pwru-pcap-filter: 'tcp[tcpflags] = tcp-syn'
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.2/32 --dport 8080 -j DROP
@@ -97,7 +97,7 @@ jobs:
       - name: Test advanced IPv6
         uses: ./.github/actions/pwru-test
         with:
-          test-name: advanced-ipv6
+          test-name: ${{ matrix.kernel }}-advanced-ipv6
           pwru-pcap-filter: 'ip6[53] & 0x3f = 0x2'
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1002 --dport 8080 -j DROP
@@ -107,7 +107,7 @@ jobs:
       - name: Test pcap filter using stack
         uses: ./.github/actions/pwru-test
         with:
-          test-name: pcap-filter-stack
+          test-name: ${{ matrix.kernel }}-pcap-filter-stack
           pwru-pcap-filter: '(((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)'
           traffic-setup: curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.1.1.1 || true
           expected-output-pattern: '1.1.1.1:80'
@@ -115,7 +115,7 @@ jobs:
       - name: Test --filter-track-skb
         uses: ./.github/actions/pwru-test
         with:
-          test-name: filter-track-skb
+          test-name: ${{ matrix.kernel }}-filter-track-skb
           pwru-flags: --filter-track-skb
           pwru-pcap-filter: dst host 10.10.20.99
           traffic-setup: |
@@ -126,7 +126,7 @@ jobs:
       - name: Test ARP filter
         uses: ./.github/actions/pwru-test
         with:
-          test-name: filter-arp
+          test-name: ${{ matrix.kernel }}-filter-arp
           pwru-pcap-filter: 'arp and arp[7] = 1 and arp[24]= 169 and arp[25] = 254 and arp[26] = 0 and arp[27] = 1'
           traffic-setup: |
             ip net a pwru
@@ -145,7 +145,7 @@ jobs:
       - name: Test --filter-ifname
         uses: ./.github/actions/pwru-test
         with:
-          test-name: filter-ifname
+          test-name: ${{ matrix.kernel }}-filter-ifname
           pwru-flags: --filter-ifname lo
           pwru-pcap-filter: icmp
           traffic-setup: |


### PR DESCRIPTION
Test logs are in LVH VM, not in host runner. So, copy them to host before fetching.

Fixes: 8d645756612 ("gh/workflows: Upload pwru logs upon failure")