### PR TITLE
Re-arrange output columns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.1/32 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.1:8080 || true
-          expected-output-pattern: '(kfree_skb_reason|kfree_skb\b).*1.0.0.1:8080'
+          expected-output-pattern: '1.0.0.1:8080.*(kfree_skb_reason|kfree_skb\b)'
 
       - name: Test basic IPv6
         uses: ./.github/actions/pwru-test
@@ -82,7 +82,7 @@ jobs:
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1001 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1001]:8080 || true
-          expected-output-pattern: '(kfree_skb_reason|kfree_skb\b).*\[2606:4700:4700::1001\]:8080'
+          expected-output-pattern: '\[2606:4700:4700::1001\]:8080.*(kfree_skb_reason|kfree_skb\b)'
 
       - name: Test advanced IPv4
         uses: ./.github/actions/pwru-test
@@ -92,7 +92,7 @@ jobs:
           traffic-setup: |
             iptables -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.2/32 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.2:8080 || true
-          expected-output-pattern: '(kfree_skb_reason|kfree_skb\b).*1.0.0.2:8080'
+          expected-output-pattern: '1.0.0.2:8080.*(kfree_skb_reason|kfree_skb\b)'
 
       - name: Test advanced IPv6
         uses: ./.github/actions/pwru-test
@@ -102,7 +102,7 @@ jobs:
           traffic-setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1002 --dport 8080 -j DROP
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1002]:8080 || true
-          expected-output-pattern: '(kfree_skb_reason|kfree_skb\b).*\[2606:4700:4700::1002\]:8080'
+          expected-output-pattern: '\[2606:4700:4700::1002\]:8080.*(kfree_skb_reason|kfree_skb\b)'
 
       - name: Test pcap filter using stack
         uses: ./.github/actions/pwru-test

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -134,7 +134,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %s %s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %-5s %s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
@@ -311,10 +311,12 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%10d %08x %16s %#04x %d %d",
+	metaData = fmt.Sprintf("%10d %08x %16s %#04x %-5s %d",
 		event.Meta.Netns, event.Meta.Mark,
 		centerAlignString(o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex), 16),
-		byteorder.NetworkToHost16(event.Meta.Proto), event.Meta.MTU, event.Meta.Len)
+		byteorder.NetworkToHost16(event.Meta.Proto),
+		fmt.Sprintf("%d", event.Meta.MTU),
+		event.Meta.Len)
 	return metaData
 }
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -119,7 +119,7 @@ func (o *output) PrintHeader() {
 	if o.flags.OutputTS == "absolute" {
 		fmt.Fprintf(o.writer, "%-12s ", "TIME")
 	}
-	fmt.Fprintf(o.writer, "%-18s %-6s %-16s", "SKB", "CPU", "PROCESS")
+	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", "SKB", "CPU", "PROCESS")
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
@@ -345,7 +345,7 @@ func (o *output) Print(event *Event) {
 
 	outFuncName := getOutFuncName(o, event, addr)
 
-	fmt.Fprintf(o.writer, "%-18s %-6s %-16s", fmt.Sprintf("%#x", event.SAddr),
+	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SAddr),
 		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("[%s]", execName))
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %-16d", ts)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -123,6 +123,12 @@ func (o *output) PrintHeader() {
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %16s", "TIMESTAMP")
 	}
+	if o.flags.OutputMeta {
+		fmt.Fprintf(o.writer, " %s %s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
+	}
+	if o.flags.OutputTuple {
+		fmt.Fprintf(o.writer, " %s", "TUPLE")
+	}
 	fmt.Fprintf(o.writer, "\n")
 }
 
@@ -288,7 +294,7 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("netns=%d mark=%#x iface=%s proto=%#04x mtu=%d len=%d",
+	metaData = fmt.Sprintf("%d %#x %s %#04x %d %d",
 		event.Meta.Netns, event.Meta.Mark,
 		o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex),
 		byteorder.NetworkToHost16(event.Meta.Proto), event.Meta.MTU, event.Meta.Len)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -134,7 +134,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %-5s %s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %-5s %-5s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
@@ -311,12 +311,12 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%10d %08x %16s %#04x %-5s %d",
+	metaData = fmt.Sprintf("%10d %08x %16s %#04x %-5s %-5s",
 		event.Meta.Netns, event.Meta.Mark,
 		centerAlignString(o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex), 16),
 		byteorder.NetworkToHost16(event.Meta.Proto),
 		fmt.Sprintf("%d", event.Meta.MTU),
-		event.Meta.Len)
+		fmt.Sprintf("%d", event.Meta.Len))
 	return metaData
 }
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -124,7 +124,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %s %s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
@@ -301,7 +301,7 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%d %#x %s %#04x %d %d",
+	metaData = fmt.Sprintf("%10d %#x %s %#04x %d %d",
 		event.Meta.Netns, event.Meta.Mark,
 		o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex),
 		byteorder.NetworkToHost16(event.Meta.Proto), event.Meta.MTU, event.Meta.Len)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -311,8 +311,8 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%10d %08x %16s %#04x %-5s %-5s",
-		event.Meta.Netns, event.Meta.Mark,
+	metaData = fmt.Sprintf("%-10s %08x %16s %#04x %-5s %-5s",
+		fmt.Sprintf("%d", event.Meta.Netns), event.Meta.Mark,
 		centerAlignString(o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex), 16),
 		byteorder.NetworkToHost16(event.Meta.Proto),
 		fmt.Sprintf("%d", event.Meta.MTU),

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -134,7 +134,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %-5s %-5s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %-5s %-5s", "NETNS", "MARK/x", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
@@ -311,8 +311,9 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%-10s %08x %16s %#04x %-5s %-5s",
-		fmt.Sprintf("%d", event.Meta.Netns), event.Meta.Mark,
+	metaData = fmt.Sprintf("%-10s %-8s %16s %#04x %-5s %-5s",
+		fmt.Sprintf("%d", event.Meta.Netns),
+		fmt.Sprintf("%x", event.Meta.Mark),
 		centerAlignString(o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex), 16),
 		byteorder.NetworkToHost16(event.Meta.Proto),
 		fmt.Sprintf("%d", event.Meta.MTU),

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -134,7 +134,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %-10s %-8s %16s %s %s %s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %-8s %16s %-6s %s %s", "NETNS", "MARK", centerAlignString("IFACE", 16), "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -117,11 +117,11 @@ func (o *output) Close() {
 
 func (o *output) PrintHeader() {
 	if o.flags.OutputTS == "absolute" {
-		fmt.Fprintf(o.writer, "%12s ", "TIME")
+		fmt.Fprintf(o.writer, "%-12s ", "TIME")
 	}
-	fmt.Fprintf(o.writer, "%18s %6s %16s", "SKB", "CPU", "PROCESS")
+	fmt.Fprintf(o.writer, "%-18s %-6s %-16s", "SKB", "CPU", "PROCESS")
 	if o.flags.OutputTS != "none" {
-		fmt.Fprintf(o.writer, " %16s", "TIMESTAMP")
+		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
 		fmt.Fprintf(o.writer, " %s %s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
@@ -330,7 +330,7 @@ func getOutFuncName(o *output, event *Event, addr uint64) string {
 
 func (o *output) Print(event *Event) {
 	if o.flags.OutputTS == "absolute" {
-		fmt.Fprintf(o.writer, "%12s ", getAbsoluteTs())
+		fmt.Fprintf(o.writer, "%-12s ", getAbsoluteTs())
 	}
 
 	execName := getExecName(int(event.PID))
@@ -345,10 +345,10 @@ func (o *output) Print(event *Event) {
 
 	outFuncName := getOutFuncName(o, event, addr)
 
-	fmt.Fprintf(o.writer, "%18s %6s %16s", fmt.Sprintf("%#x", event.SAddr),
+	fmt.Fprintf(o.writer, "%-18s %-6s %-16s", fmt.Sprintf("%#x", event.SAddr),
 		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("[%s]", execName))
 	if o.flags.OutputTS != "none" {
-		fmt.Fprintf(o.writer, " %16d", ts)
+		fmt.Fprintf(o.writer, " %-16d", ts)
 	}
 	o.lastSeenSkb[event.SAddr] = event.Timestamp
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -124,7 +124,7 @@ func (o *output) PrintHeader() {
 		fmt.Fprintf(o.writer, " %-16s", "TIMESTAMP")
 	}
 	if o.flags.OutputMeta {
-		fmt.Fprintf(o.writer, " %-10s %s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
+		fmt.Fprintf(o.writer, " %-10s %-8s %s %s %s %s", "NETNS", "MARK", "IFACE", "PROTO", "MTU", "LEN")
 	}
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
@@ -301,7 +301,7 @@ func getShinfoData(event *Event, o *output) (shinfoData string) {
 }
 
 func getMetaData(event *Event, o *output) (metaData string) {
-	metaData = fmt.Sprintf("%10d %#x %s %#04x %d %d",
+	metaData = fmt.Sprintf("%10d %08x %s %#04x %d %d",
 		event.Meta.Netns, event.Meta.Mark,
 		o.getIfaceName(event.Meta.Netns, event.Meta.Ifindex),
 		byteorder.NetworkToHost16(event.Meta.Proto), event.Meta.MTU, event.Meta.Len)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -346,6 +346,16 @@ func getOutFuncName(o *output, event *Event, addr uint64) string {
 	return outFuncName
 }
 
+var maxTupleLengthSeen int
+
+func fprintTupleData(writer *os.File, tupleData string) {
+	if len(tupleData) > maxTupleLengthSeen {
+		maxTupleLengthSeen = len(tupleData)
+	}
+	formatter := fmt.Sprintf(" %%-%ds", maxTupleLengthSeen)
+	fmt.Fprintf(writer, formatter, tupleData)
+}
+
 func (o *output) Print(event *Event) {
 	if o.flags.OutputTS == "absolute" {
 		fmt.Fprintf(o.writer, "%-12s ", getAbsoluteTs())
@@ -375,7 +385,7 @@ func (o *output) Print(event *Event) {
 	}
 
 	if o.flags.OutputTuple {
-		fmt.Fprintf(o.writer, " %s", getTupleData(event))
+		fprintTupleData(o.writer, getTupleData(event))
 	}
 
 	fmt.Fprintf(o.writer, " %s", outFuncName)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -216,9 +216,15 @@ func getRelativeTs(event *Event, o *output) uint64 {
 
 func getExecName(pid int) string {
 	p, err := ps.FindProcess(pid)
-	execName := fmt.Sprintf("<empty>:(%d)", pid)
+	execName := fmt.Sprintf("<empty>:%d", pid)
 	if err == nil && p != nil {
-		return fmt.Sprintf("%s:%d", p.ExecutablePath(), pid)
+		execName = fmt.Sprintf("%s:%d", p.ExecutablePath(), pid)
+		if len(execName) > 16 {
+			execName = execName[len(execName)-16:]
+			bexecName := []byte(execName)
+			bexecName[0] = '~'
+			execName = string(bexecName)
+		}
 	}
 	return execName
 }
@@ -346,7 +352,7 @@ func (o *output) Print(event *Event) {
 	outFuncName := getOutFuncName(o, event, addr)
 
 	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SAddr),
-		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("[%s]", execName))
+		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("%s", execName))
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %-16d", ts)
 	}

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -119,7 +119,7 @@ func (o *output) PrintHeader() {
 	if o.flags.OutputTS == "absolute" {
 		fmt.Fprintf(o.writer, "%12s ", "TIME")
 	}
-	fmt.Fprintf(o.writer, "%18s %6s %16s %24s", "SKB", "CPU", "PROCESS", "FUNC")
+	fmt.Fprintf(o.writer, "%18s %6s %16s", "SKB", "CPU", "PROCESS")
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %16s", "TIMESTAMP")
 	}
@@ -129,6 +129,7 @@ func (o *output) PrintHeader() {
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", "TUPLE")
 	}
+	fmt.Fprintf(o.writer, " %s", "FUNC")
 	fmt.Fprintf(o.writer, "\n")
 }
 
@@ -344,8 +345,8 @@ func (o *output) Print(event *Event) {
 
 	outFuncName := getOutFuncName(o, event, addr)
 
-	fmt.Fprintf(o.writer, "%18s %6s %16s %24s", fmt.Sprintf("%#x", event.SAddr),
-		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("[%s]", execName), outFuncName)
+	fmt.Fprintf(o.writer, "%18s %6s %16s", fmt.Sprintf("%#x", event.SAddr),
+		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("[%s]", execName))
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %16d", ts)
 	}
@@ -358,6 +359,8 @@ func (o *output) Print(event *Event) {
 	if o.flags.OutputTuple {
 		fmt.Fprintf(o.writer, " %s", getTupleData(event))
 	}
+
+	fmt.Fprintf(o.writer, " %s", outFuncName)
 
 	if o.flags.OutputStack && event.PrintStackId > 0 {
 		fmt.Fprintf(o.writer, "%s", getStackData(event, o))


### PR DESCRIPTION
The output of `pwru --output-meta --output-tuple` now is like:

```
SKB                CPU PROCESS          NETNS      MARK          IFACE       PROTO  MTU   LEN   TUPLE FUNC
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        netlink_broadcast
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        netlink_trim
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        sk_filter_trim_cap
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        security_sock_rcv_skb
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        apparmor_socket_sock_rcv_skb
0xffff9fc1014a8700 0   ~/ampdaemon:4417          0 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        netlink_skb_set_owner_r
0xffff9fc1014a8700 0   ~/ampdaemon:4417 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        __netlink_sendskb
0xffff9fc1014a8700 0   ~/ampdaemon:4417 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        skb_queue_tail
0xffff9fc1014a8700 0   ~/ampdaemon:4417 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        consume_skb
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        skb_free_datagram
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        consume_skb
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        skb_release_head_state
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        netlink_skb_destructor
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        sock_rfree
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        skb_release_data
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        skb_free_head
0xffff9fc1014a8700 11  ~code42-aat:1053 4026531840 00000000        0         0x0000 0     76    0.0.0.0:0->1.0.0.0:0()                        kfree_skbmem
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000        0         0x0000 0     150   172.19.0.6:6443->172.19.0.4:55646(tcp)        ip_local_out
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000        0         0x0000 0     150   172.19.0.6:6443->172.19.0.4:55646(tcp)        __ip_local_out
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000        0         0x0800 0     150   172.19.0.6:6443->172.19.0.4:55646(tcp)        nf_hook_slow
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000        0         0x0800 0     150   172.19.0.6:6443->172.19.0.4:55646(tcp)        ip_output
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  150   172.19.0.6:6443->172.19.0.4:55646(tcp)        nf_hook_slow
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  150   172.19.0.6:6443->172.19.0.4:55646(tcp)        apparmor_ip_postroute
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  150   172.19.0.6:6443->172.19.0.4:55646(tcp)        ip_finish_output
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  150   172.19.0.6:6443->172.19.0.4:55646(tcp)        __ip_finish_output
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  150   172.19.0.6:6443->172.19.0.4:55646(tcp)        ip_finish_output2
0xffff9fc1ad4c84e8 2   ~-apiserver:5328 4026533261 00000000     eth0:22      0x0800 1500  164   172.19.0.6:6443->172.19.0.4:55646(tcp)        __dev_queue_xmit
```

Comparing to original output, now it shows all data with less width in a clearer way:

Original：

```
               SKB    CPU          PROCESS                     FUNC
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904] kfree_skb_reason(SKB_DROP_REASON_NOT_SPECIFIED) netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904]   skb_release_head_state netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904]               sock_rfree netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904]         skb_release_data netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904]            skb_free_head netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
0xffff9fc1ad53c800      4 [irq/177-iwlwifi:queue_2:904]             kfree_skbmem netns=4026531840 mark=0x0 iface=0 proto=0x0800 mtu=0 len=0 1.1.1.1:80->10.103.80.118:59176(tcp)
```

Now:

```
SKB                CPU PROCESS          NETNS      MARK          IFACE       PROTO  MTU   LEN   TUPLE FUNC
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) kfree_skb_reason(SKB_DROP_REASON_NOT_SPECIFIED)
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) skb_release_head_state
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) sock_rfree
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) skb_release_data
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) skb_free_head
0xffff9fc1ad53ca00 4   ~ifi:queue_2:904 4026531840 00000000        0         0x0800 0     0     1.1.1.1:80->10.103.80.118:49544(tcp) kfree_skbmem
```