### PR TITLE
Fix skb tracing on veth

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -159,7 +159,7 @@ func (o *output) PrintJson(event *Event) {
 	d := &jsonPrinter{}
 
 	// add the data to the struct
-	d.Skb = fmt.Sprintf("%#x", event.SAddr)
+	d.Skb = fmt.Sprintf("%#x", event.SkbHead)
 	d.Cpu = event.CPU
 	d.Process = getExecName(int(event.PID))
 	d.Func = getOutFuncName(o, event, event.Addr)
@@ -167,7 +167,7 @@ func (o *output) PrintJson(event *Event) {
 		d.CallerFunc = o.addr2name.findNearestSym(event.CallerAddr)
 	}
 
-	o.lastSeenSkb[event.SAddr] = event.Timestamp
+	o.lastSeenSkb[event.SkbHead] = event.Timestamp
 
 	// add the timestamp to the struct if it is not set to none
 	if o.flags.OutputTS != "none" {
@@ -228,7 +228,7 @@ func getAbsoluteTs() string {
 
 func getRelativeTs(event *Event, o *output) uint64 {
 	ts := event.Timestamp
-	if last, found := o.lastSeenSkb[event.SAddr]; found {
+	if last, found := o.lastSeenSkb[event.SkbHead]; found {
 		ts = ts - last
 	} else {
 		ts = 0
@@ -396,12 +396,12 @@ func (o *output) Print(event *Event) {
 
 	outFuncName := getOutFuncName(o, event, addr)
 
-	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SAddr),
+	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SkbHead),
 		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("%s", execName))
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %-16d", ts)
 	}
-	o.lastSeenSkb[event.SAddr] = event.Timestamp
+	o.lastSeenSkb[event.SkbHead] = event.Timestamp
 
 	if o.flags.OutputMeta {
 		fmt.Fprintf(o.writer, " %s", getMetaData(event, o))

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -143,7 +143,7 @@ type Event struct {
 	Type          uint32
 	Addr          uint64
 	CallerAddr    uint64
-	SAddr         uint64
+	SkbHead       uint64
 	Timestamp     uint64
 	PrintSkbId    uint64
 	PrintShinfoId uint64


### PR DESCRIPTION
After https://github.com/cilium/pwru/pull/339, skb_addresses map stores skb->head as key, but kprobe prog on veth_convert_skb_to_xdp_buff still lookup map by &skb. This PR makes things right.

Fixes: #391 