### PR TITLE
bpf: Fix veth tracing + --track-by-stackid

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -438,13 +438,13 @@ handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_s
 			goto cont;
 		}
 
-		if (cfg->track_skb_by_stackid && bpf_map_lookup_elem(&stackid_skb, &stackid)) {
-			tracked_by = TRACKED_BY_STACKID;
+		if (filter(skb)) {
+			tracked_by = TRACKED_BY_FILTER;
 			goto cont;
 		}
 
-		if (filter(skb)) {
-			tracked_by = TRACKED_BY_FILTER;
+		if (cfg->track_skb_by_stackid && bpf_map_lookup_elem(&stackid_skb, &stackid)) {
+			tracked_by = TRACKED_BY_STACKID;
 			goto cont;
 		}
 
@@ -538,7 +538,7 @@ int kprobe_skb_lifetime_termination(struct pt_regs *ctx) {
 	if (cfg->track_skb_by_stackid) {
 		u64 stackid = get_stackid(ctx);
 		bpf_map_delete_elem(&stackid_skb, &stackid);
-		bpf_map_delete_elem(&skb_stackid, &skb_head);
+		bpf_map_delete_elem(&skb_stackid, &skb);
 	}
 
 	return BPF_OK;


### PR DESCRIPTION
https://github.com/cilium/pwru/pull/391 allows --track-skb to track new skb on veth, it relies on a map lookup to decide whether to track or not:

```
SEC("kprobe/veth_convert_skb_to_xdp_buff")
int kprobe_veth_convert_skb_to_xdp_buff(struct pt_regs *ctx) {
[...]
	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
	if (bpf_map_lookup_elem(&skb_heads, &skb_head)) {
[...]
	}
	return BPF_OK;
}
```

However, when --track-skb-by-stackid is used along with --track-skb, the tracked skbs have risks not being recorded in skb_heads map.

This is because:
1. https://github.com/cilium/pwru/pull/384 no more updates skb_heads map when track reason is "by_stackid".
2. https://github.com/cilium/pwru/pull/339 changes --track-skb from using &skb to skb->head.

So imagine an skb whose original skb->head = 0xa, the value is updated to 0xb after a while. The first time pwru sees this skb, skb_heads map will insert 0xa entry, this is correct. However, after skb->head being set to 0xb, pwru will verdict the skb of being tracked due to "by_stackid", we end up not inserting 0xb entry into skb_heads map.

Then the skb reaches veth, pwru can't find an entry by looking up 0xb from skb_heads map, we are losing track of veth skb again.

This patch fixes the issue by raising the priority of track_by_filter: if an skb can be defined as both tracked_by_filter and tracked_by_stackid, use tracked_by_filter over tracked_by_stackid.

Another issue https://github.com/cilium/pwru/pull/339 brings about is, an skb can have multiple skb->head stored in skb_heads map during its lifetime, but we only clean the latest value at
kprobe_skb_lifetime_termination. This issue is beyond this patch.