### PR TITLE
Fix tracking skb

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -130,7 +130,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u64);
-	__type(value, bool);
+	__type(value, struct skb *);
 	__uint(max_entries, MAX_TRACK_SIZE);
 } xdp_dhs_skb_heads SEC(".maps");
 
@@ -474,6 +474,8 @@ cont:
 
 	if (cfg->track_skb && tracked_by == TRACKED_BY_FILTER) {
 		bpf_map_update_elem(&skb_addresses, &skb_addr, &TRUE, BPF_ANY);
+		if (cfg->track_xdp)
+			bpf_map_update_elem(&xdp_dhs_skb_heads, &skb_head, &skb_addr, BPF_ANY);
 	}
 
 	if (cfg->track_skb_by_stackid && tracked_by != TRACKED_BY_STACKID) {
@@ -682,12 +684,19 @@ set_xdp_output(void *ctx, struct xdp_buff *xdp, struct event_t *event) {
 SEC("fentry/xdp")
 int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
 	struct event_t event = {};
+	u64 xdp_dhs = (u64) BPF_CORE_READ(xdp, data_hard_start);
 
 	if (cfg->is_set) {
-		if (!filter_xdp(xdp)) {
-			return BPF_OK;
+		if (cfg->track_skb && bpf_map_lookup_elem(&xdp_dhs_skb_heads, &xdp_dhs)) {
+			bpf_map_delete_elem(&xdp_dhs_skb_heads, &xdp_dhs);
+			goto cont;
 		}
 
+		if (filter_xdp(xdp)) {
+			goto cont;
+		}
+
+cont:
 		set_xdp_output(ctx, xdp, &event);
 	}
 
@@ -705,7 +714,7 @@ int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
 SEC("fexit/xdp")
 int BPF_PROG(fexit_xdp, struct xdp_buff *xdp) {
 	u64 xdp_dhs = (u64) BPF_CORE_READ(xdp, data_hard_start);
-	bpf_map_update_elem(&xdp_dhs_skb_heads, &xdp_dhs, &TRUE, BPF_ANY);
+	bpf_map_update_elem(&xdp_dhs_skb_heads, &xdp_dhs, &xdp, BPF_ANY);
 	return BPF_OK;
 }
 

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -35,6 +35,7 @@ enum {
 	TRACKED_BY_FILTER = (1 << 0),
 	TRACKED_BY_SKB = (1 << 1),
 	TRACKED_BY_STACKID = (1 << 2),
+	TRACKED_BY_XDP = (1 << 3),
 };
 
 union addr {
@@ -126,6 +127,13 @@ struct {
 	__uint(max_entries, MAX_TRACK_SIZE);
 } stackid_skb SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u64);
+	__type(value, bool);
+	__uint(max_entries, MAX_TRACK_SIZE);
+} xdp_dhs_skb_heads SEC(".maps");
+
 struct config {
 	u32 netns;
 	u32 mark;
@@ -140,7 +148,8 @@ struct config {
 	u8 is_set: 1;
 	u8 track_skb: 1;
 	u8 track_skb_by_stackid: 1;
-	u8 unused: 5;
+	u8 track_xdp: 1;
+	u8 unused: 4;
 } __attribute__((packed));
 
 static volatile const struct config CFG;
@@ -427,12 +436,21 @@ static __noinline bool
 handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_stackid) {
 	u8 tracked_by;
 	u64 skb_addr = (u64) skb;
+	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
 	u64 stackid;
 
 	if (cfg->track_skb_by_stackid)
 		stackid = _stackid ? *_stackid : get_stackid(ctx);
 
 	if (cfg->is_set) {
+		if (cfg->track_xdp && cfg->track_skb) {
+			if (bpf_map_lookup_elem(&xdp_dhs_skb_heads, &skb_head)) {
+				tracked_by = TRACKED_BY_XDP;
+				bpf_map_delete_elem(&xdp_dhs_skb_heads, &skb_head);
+				goto cont;
+			}
+		}
+
 		if (cfg->track_skb && bpf_map_lookup_elem(&skb_addresses, &skb_addr)) {
 			tracked_by = _stackid ? TRACKED_BY_STACKID : TRACKED_BY_SKB;
 			goto cont;
@@ -663,19 +681,10 @@ set_xdp_output(void *ctx, struct xdp_buff *xdp, struct event_t *event) {
 
 SEC("fentry/xdp")
 int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
-	u64 skb_head = (u64) BPF_CORE_READ(xdp, data_hard_start);
 	struct event_t event = {};
 
 	if (cfg->is_set) {
-		if (cfg->track_skb) {
-			if (!bpf_map_lookup_elem(&skb_addresses, &skb_head)) {
-				if (!filter_xdp(xdp))
-					return BPF_OK;
-
-				bpf_map_update_elem(&skb_addresses, &skb_head, &TRUE, BPF_ANY);
-			}
-
-		} else if (!filter_xdp(xdp)) {
+		if (!filter_xdp(xdp)) {
 			return BPF_OK;
 		}
 
@@ -685,11 +694,18 @@ int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
 	event.pid = bpf_get_current_pid_tgid() >> 32;
 	event.ts = bpf_ktime_get_ns();
 	event.cpu_id = bpf_get_smp_processor_id();
-	event.skb_addr = (u64) skb_head;
+	event.skb_addr = (u64) &xdp;
 	event.addr = BPF_PROG_ADDR;
 	event.type = EVENT_TYPE_XDP;
 	bpf_map_push_elem(&events, &event, BPF_EXIST);
 
+	return BPF_OK;
+}
+
+SEC("fexit/xdp")
+int BPF_PROG(fexit_xdp, struct xdp_buff *xdp) {
+	u64 xdp_dhs = (u64) BPF_CORE_READ(xdp, data_hard_start);
+	bpf_map_update_elem(&xdp_dhs_skb_heads, &xdp_dhs, &TRUE, BPF_ANY);
 	return BPF_OK;
 }
 

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -79,7 +79,7 @@ struct event_t {
 	u32 type;
 	u64 addr;
 	u64 caller_addr;
-	u64 skb_head;
+	u64 skb_addr;
 	u64 ts;
 	typeof(print_skb_id) print_skb_id;
 	typeof(print_shinfo_id) print_shinfo_id;
@@ -103,7 +103,7 @@ struct {
 	__type(key, __u64);
 	__type(value, bool);
 	__uint(max_entries, MAX_TRACK_SIZE);
-} skb_heads SEC(".maps");
+} skb_addresses SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -426,14 +426,14 @@ set_output(void *ctx, struct sk_buff *skb, struct event_t *event) {
 static __noinline bool
 handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_stackid) {
 	u8 tracked_by;
-	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
+	u64 skb_addr = (u64) skb;
 	u64 stackid;
 
 	if (cfg->track_skb_by_stackid)
 		stackid = _stackid ? *_stackid : get_stackid(ctx);
 
 	if (cfg->is_set) {
-		if (cfg->track_skb && bpf_map_lookup_elem(&skb_heads, &skb_head)) {
+		if (cfg->track_skb && bpf_map_lookup_elem(&skb_addresses, &skb_addr)) {
 			tracked_by = _stackid ? TRACKED_BY_STACKID : TRACKED_BY_SKB;
 			goto cont;
 		}
@@ -455,7 +455,7 @@ cont:
 	}
 
 	if (cfg->track_skb && tracked_by == TRACKED_BY_FILTER) {
-		bpf_map_update_elem(&skb_heads, &skb_head, &TRUE, BPF_ANY);
+		bpf_map_update_elem(&skb_addresses, &skb_addr, &TRUE, BPF_ANY);
 	}
 
 	if (cfg->track_skb_by_stackid && tracked_by != TRACKED_BY_STACKID) {
@@ -481,7 +481,7 @@ kprobe_skb(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip, u64 *
 	if (!handle_everything(skb, ctx, &event, _stackid))
 		return BPF_OK;
 
-	event.skb_head = (u64) BPF_CORE_READ(skb, head);
+	event.skb_addr = (u64) skb;
 	event.addr = has_get_func_ip ? bpf_get_func_ip(ctx) : PT_REGS_IP(ctx);
 	event.param_second = PT_REGS_PARM2(ctx);
 	if (CFG.output_caller)
@@ -531,14 +531,14 @@ int kprobe_skb_by_stackid(struct pt_regs *ctx) {
 SEC("kprobe/skb_lifetime_termination")
 int kprobe_skb_lifetime_termination(struct pt_regs *ctx) {
 	struct sk_buff *skb = (typeof(skb)) PT_REGS_PARM1(ctx);
-	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
+	u64 skb_addr = (u64) skb;
 
-	bpf_map_delete_elem(&skb_heads, &skb_head);
+	bpf_map_delete_elem(&skb_addresses, &skb_addr);
 
 	if (cfg->track_skb_by_stackid) {
 		u64 stackid = get_stackid(ctx);
 		bpf_map_delete_elem(&stackid_skb, &stackid);
-		bpf_map_delete_elem(&skb_stackid, &skb_head);
+		bpf_map_delete_elem(&skb_stackid, &skb_addr);
 	}
 
 	return BPF_OK;
@@ -546,10 +546,10 @@ int kprobe_skb_lifetime_termination(struct pt_regs *ctx) {
 
 static __always_inline int
 track_skb_clone(struct sk_buff *old, struct sk_buff *new) {
-	u64 skb_addr_old = (u64) BPF_CORE_READ(old, head);
-	u64 skb_addr_new = (u64) BPF_CORE_READ(new, head);
-	if (bpf_map_lookup_elem(&skb_heads, &skb_addr_old))
-		bpf_map_update_elem(&skb_heads, &skb_addr_new, &TRUE, BPF_ANY);
+	u64 skb_addr_old = (u64) old;
+	u64 skb_addr_new = (u64) new;
+	if (bpf_map_lookup_elem(&skb_addresses, &skb_addr_old))
+		bpf_map_update_elem(&skb_addresses, &skb_addr_new, &TRUE, BPF_ANY);
 
 	return BPF_OK;
 }
@@ -577,7 +577,7 @@ int BPF_PROG(fentry_tc, struct sk_buff *skb) {
 	if (!handle_everything(skb, ctx, &event, NULL))
 		return BPF_OK;
 
-	event.skb_head = (u64) BPF_CORE_READ(skb, head);
+	event.skb_addr = (u64) skb;
 	event.addr = BPF_PROG_ADDR;
 	event.type = EVENT_TYPE_TC;
 	bpf_map_push_elem(&events, &event, BPF_EXIST);
@@ -668,11 +668,11 @@ int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
 
 	if (cfg->is_set) {
 		if (cfg->track_skb) {
-			if (!bpf_map_lookup_elem(&skb_heads, &skb_head)) {
+			if (!bpf_map_lookup_elem(&skb_addresses, &skb_head)) {
 				if (!filter_xdp(xdp))
 					return BPF_OK;
 
-				bpf_map_update_elem(&skb_heads, &skb_head, &TRUE, BPF_ANY);
+				bpf_map_update_elem(&skb_addresses, &skb_head, &TRUE, BPF_ANY);
 			}
 
 		} else if (!filter_xdp(xdp)) {
@@ -685,7 +685,7 @@ int BPF_PROG(fentry_xdp, struct xdp_buff *xdp) {
 	event.pid = bpf_get_current_pid_tgid() >> 32;
 	event.ts = bpf_ktime_get_ns();
 	event.cpu_id = bpf_get_smp_processor_id();
-	event.skb_head = (u64) skb_head;
+	event.skb_addr = (u64) skb_head;
 	event.addr = BPF_PROG_ADDR;
 	event.type = EVENT_TYPE_XDP;
 	bpf_map_push_elem(&events, &event, BPF_EXIST);
@@ -698,8 +698,8 @@ int kprobe_veth_convert_skb_to_xdp_buff(struct pt_regs *ctx) {
 	struct sk_buff **pskb = (struct sk_buff **)PT_REGS_PARM3(ctx);
 	struct sk_buff *skb;
 	bpf_probe_read_kernel(&skb, sizeof(skb), (void *)pskb);
-	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
-	if (bpf_map_lookup_elem(&skb_heads, &skb_head)) {
+	u64 skb_addr = (u64) skb;
+	if (bpf_map_lookup_elem(&skb_addresses, &skb_addr)) {
 		u64 pid_tgid = bpf_get_current_pid_tgid();
 		bpf_map_update_elem(&veth_skbs, &pid_tgid, &pskb, BPF_ANY);
 	}
@@ -713,8 +713,8 @@ int kretprobe_veth_convert_skb_to_xdp_buff(struct pt_regs *ctx) {
 	if (pskb && *pskb) {
 		struct sk_buff *skb;
 		bpf_probe_read_kernel(&skb, sizeof(skb), (void *)*pskb);
-		u64 skb_head = (u64) BPF_CORE_READ(skb, head);
-		bpf_map_update_elem(&skb_heads, &skb_head, &TRUE, BPF_ANY);
+		u64 skb_addr = (u64) skb;
+		bpf_map_update_elem(&skb_addresses, &skb_addr, &TRUE, BPF_ANY);
 		bpf_map_delete_elem(&veth_skbs, &pid_tgid);
 	}
 	return BPF_OK;

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -28,6 +28,7 @@ const (
 	IsSetMask uint8 = 1 << iota
 	TrackSkbMask
 	TrackSkbByStackidMask
+	TrackXDPMask
 )
 
 // Version is the pwru version and is set at compile time via LDFLAGS-
@@ -70,6 +71,9 @@ func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	}
 	if flags.FilterTrackSkbByStackid {
 		cfg.FilterFlags |= TrackSkbByStackidMask
+	}
+	if flags.FilterTraceXdp {
+		cfg.FilterFlags |= TrackXDPMask
 	}
 
 	netnsID, ns, err := parseNetns(flags.FilterNetns)

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -159,7 +159,7 @@ func (o *output) PrintJson(event *Event) {
 	d := &jsonPrinter{}
 
 	// add the data to the struct
-	d.Skb = fmt.Sprintf("%#x", event.SkbHead)
+	d.Skb = fmt.Sprintf("%#x", event.SkbAddr)
 	d.Cpu = event.CPU
 	d.Process = getExecName(int(event.PID))
 	d.Func = getOutFuncName(o, event, event.Addr)
@@ -167,7 +167,7 @@ func (o *output) PrintJson(event *Event) {
 		d.CallerFunc = o.addr2name.findNearestSym(event.CallerAddr)
 	}
 
-	o.lastSeenSkb[event.SkbHead] = event.Timestamp
+	o.lastSeenSkb[event.SkbAddr] = event.Timestamp
 
 	// add the timestamp to the struct if it is not set to none
 	if o.flags.OutputTS != "none" {
@@ -228,7 +228,7 @@ func getAbsoluteTs() string {
 
 func getRelativeTs(event *Event, o *output) uint64 {
 	ts := event.Timestamp
-	if last, found := o.lastSeenSkb[event.SkbHead]; found {
+	if last, found := o.lastSeenSkb[event.SkbAddr]; found {
 		ts = ts - last
 	} else {
 		ts = 0
@@ -396,12 +396,12 @@ func (o *output) Print(event *Event) {
 
 	outFuncName := getOutFuncName(o, event, addr)
 
-	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SkbHead),
+	fmt.Fprintf(o.writer, "%-18s %-3s %-16s", fmt.Sprintf("%#x", event.SkbAddr),
 		fmt.Sprintf("%d", event.CPU), fmt.Sprintf("%s", execName))
 	if o.flags.OutputTS != "none" {
 		fmt.Fprintf(o.writer, " %-16d", ts)
 	}
-	o.lastSeenSkb[event.SkbHead] = event.Timestamp
+	o.lastSeenSkb[event.SkbAddr] = event.Timestamp
 
 	if o.flags.OutputMeta {
 		fmt.Fprintf(o.writer, " %s", getMetaData(event, o))

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -190,6 +190,9 @@ func TraceXDP(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
 	if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fentry_xdp"); err != nil {
 		log.Fatalf("failed to trace XDP progs: %v", err)
 	}
+	if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fexit_xdp"); err != nil {
+		log.Fatalf("failed to trace XDP progs: %v", err)
+	}
 
 	return &t
 }

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -143,7 +143,7 @@ type Event struct {
 	Type          uint32
 	Addr          uint64
 	CallerAddr    uint64
-	SkbHead       uint64
+	SkbAddr       uint64
 	Timestamp     uint64
 	PrintSkbId    uint64
 	PrintShinfoId uint64

--- a/main.go
+++ b/main.go
@@ -131,7 +131,8 @@ func main() {
 			"fexit_skb_clone",
 			"fexit_skb_copy",
 			"kprobe_veth_convert_skb_to_xdp_buff",
-			"kretprobe_veth_convert_skb_to_xdp_buff":
+			"kretprobe_veth_convert_skb_to_xdp_buff",
+			"fexit_xdp":
 			continue
 		}
 		if name == "fentry_xdp" {
@@ -176,6 +177,7 @@ func main() {
 		bpfSpecFentryXdp = bpfSpec.Copy()
 		bpfSpecFentryXdp.Programs = map[string]*ebpf.ProgramSpec{
 			"fentry_xdp": bpfSpecFentryXdp.Programs["fentry_xdp"],
+			"fexit_xdp":  bpfSpecFentryXdp.Programs["fexit_xdp"],
 		}
 	}
 
@@ -183,6 +185,7 @@ func main() {
 	// they should be deleted from the spec.
 	delete(bpfSpec.Programs, "fentry_tc")
 	delete(bpfSpec.Programs, "fentry_xdp")
+	delete(bpfSpec.Programs, "fexit_xdp")
 
 	// If not tracking skb, deleting the skb-tracking programs to reduce loading
 	// time.


### PR DESCRIPTION
This PR uses &skb to track skb instead of skb->head to prevent several issues. XDP tracing is also taken care of by introducing a new bpf map `xdp_dhs_skb_heads`.