### PR TITLE
Bump Go version to 1.23.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.21.5
+          go-version: 1.23.1
 
       - name: Generate the artifacts
         run: make release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
       with:
-        go-version: 1.21.5
+        go-version: 1.23.1
 
     - name: Check module vendoring
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,13 @@
-FROM ubuntu:22.04 AS build
+FROM docker.io/library/golang:1.23.1 AS build
 
-ENV PATH $PATH:/usr/local/go/bin
-
-RUN apt update -y -q && \
-    DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y -q \
-        curl \
-        build-essential \
-        ca-certificates \
-        wget \
-        gnupg2 \
-        git \
-        llvm \
-        clang \
-        gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
-    curl -s https://storage.googleapis.com/golang/go1.23.1.linux-amd64.tar.gz | tar -v -C /usr/local -xz
+RUN apt update && \
+    apt install -y make git clang-15 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang
 
 WORKDIR /pwru
 COPY . .
-RUN make && \
-    chmod a+x /pwru
+RUN make local-release
+RUN tar xfv release/pwru-linux-amd64.tar.gz
 
 FROM busybox
 COPY --from=build /pwru/pwru /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update -y -q && \
         llvm \
         clang \
         gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
-    curl -s https://storage.googleapis.com/golang/go1.20.5.linux-amd64.tar.gz | tar -v -C /usr/local -xz
+    curl -s https://storage.googleapis.com/golang/go1.23.1.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 
 WORKDIR /pwru
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /pwru \
-		--volume `pwd`:/pwru docker.io/library/golang:1.21.5 \
+		--volume `pwd`:/pwru docker.io/library/golang:1.23.1 \
 		sh -c "apt update && apt install -y make git clang-15 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
 			ln -s /usr/bin/clang-15 /usr/bin/clang && \
 			git config --global --add safe.directory /pwru && \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cilium/pwru
 
-go 1.21.0
-
-toolchain go1.21.6
+go 1.23.1
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.5


### PR DESCRIPTION
This also fixes Docker build issues.

Suggested-by:  André Martins <andre@cilium.io>