### PR TITLE
Fix broken --filter-trace-tc and --filter-trace-xdp

### DIFF
--- a/internal/pwru/ksym.go
+++ b/internal/pwru/ksym.go
@@ -58,7 +58,7 @@ func ParseKallsyms(funcs Funcs, all bool) (Addr2Name, BpfProgName2Addr, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.Split(scanner.Text(), " ")
-		name, isBpfProg := extractBpfProgName(line[2])
+		name := strings.ReplaceAll(line[2], "\t", "")
 		if all || (funcs[name] > 0) {
 			addr, err := strconv.ParseUint(line[0], 16, 64)
 			if err != nil {
@@ -73,7 +73,7 @@ func ParseKallsyms(funcs Funcs, all bool) (Addr2Name, BpfProgName2Addr, error) {
 			if all {
 				a2n.Addr2NameSlice = append(a2n.Addr2NameSlice, sym)
 			}
-			if isBpfProg {
+			if isBpfProg := strings.HasSuffix(name, "[bpf]"); isBpfProg {
 				n2a[name] = addr
 			}
 		}
@@ -87,8 +87,4 @@ func ParseKallsyms(funcs Funcs, all bool) (Addr2Name, BpfProgName2Addr, error) {
 	}
 
 	return a2n, n2a, nil
-}
-
-func extractBpfProgName(name string) (string, bool) {
-	return strings.ReplaceAll(name, "\t", ""), strings.HasSuffix(name, "[bpf]")
 }

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -254,7 +254,7 @@ func getAddrByArch(event *Event, o *output) (addr uint64) {
 	switch runtime.GOARCH {
 	case "amd64":
 		addr = event.Addr
-		if !o.kprobeMulti {
+		if !o.kprobeMulti && event.Type == eventTypeKprobe {
 			addr -= 1
 		}
 	case "arm64":
@@ -365,8 +365,10 @@ func getOutFuncName(o *output, event *Event, addr uint64) string {
 	return outFuncName
 }
 
-var maxTupleLengthSeen int
-var maxFuncLengthSeen int
+var (
+	maxTupleLengthSeen int
+	maxFuncLengthSeen  int
+)
 
 func fprintWithPadding(writer *os.File, data string, maxLenSeen *int) {
 	if len(data) > *maxLenSeen {
@@ -412,7 +414,6 @@ func (o *output) Print(event *Event) {
 		fprintWithPadding(o.writer, outFuncName, &maxFuncLengthSeen)
 		fmt.Fprintf(o.writer, " %s", o.addr2name.findNearestSym(event.CallerAddr))
 	} else {
-
 		fmt.Fprintf(o.writer, " %s", outFuncName)
 	}
 

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -189,11 +189,20 @@ func TraceXDP(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
 	log.Printf("Attaching xdp progs...\n")
 
 	var t tracing
-	if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fentry_xdp"); err != nil {
-		log.Fatalf("failed to trace XDP progs: %v", err)
+	{
+		spec := spec.Copy()
+		delete(spec.Programs, "fexit_xdp")
+		if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fentry_xdp"); err != nil {
+			log.Fatalf("failed to trace XDP progs: %v", err)
+		}
 	}
-	if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fexit_xdp"); err != nil {
-		log.Fatalf("failed to trace XDP progs: %v", err)
+
+	{
+		spec := spec.Copy()
+		delete(spec.Programs, "fentry_xdp")
+		if err := t.trace(coll, spec, opts, outputSkb, outputShinfo, n2a, ebpf.XDP, "fexit_xdp"); err != nil {
+			log.Fatalf("failed to trace XDP progs: %v", err)
+		}
 	}
 
 	return &t

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -64,7 +64,7 @@ func (t *tracing) traceProg(spec *ebpf.CollectionSpec,
 	opts *ebpf.CollectionOptions, prog *ebpf.Program, n2a BpfProgName2Addr,
 	tracingName string,
 ) error {
-	entryFn, name, err := getEntryFuncName(prog)
+	entryFn, progName, tag, err := getBpfProgInfo(prog)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			log.Printf("Skip tracing bpf prog %s because cannot find its entry function name", prog)
@@ -80,11 +80,13 @@ func (t *tracing) traceProg(spec *ebpf.CollectionSpec,
 	// distinguish which exact bpf prog is called.
 	//   -- @jschwinger233
 
-	addr, ok := n2a[entryFn]
+	progKsym := fmt.Sprintf("bpf_prog_%s_%s[bpf]", tag, entryFn)
+	addr, ok := n2a[progKsym]
 	if !ok {
-		addr, ok = n2a[name]
+		progKsym = fmt.Sprintf("bpf_prog_%s_%s[bpf]", tag, progName)
+		addr, ok = n2a[progKsym]
 		if !ok {
-			return fmt.Errorf("failed to find address for function %s of bpf prog %v", name, prog)
+			return fmt.Errorf("failed to find address for function %s of bpf prog %v", progName, prog)
 		}
 	}
 


### PR DESCRIPTION
When I want to troubleshoot a network issue with `--filter-trace-tc`, it cannot to get the address of bpf prog.

After fixing `--filter-trace-tc` issue, I find it fails to run with `--filter-trace-xdp` too. So, I fix the broken `--filter-trace-xdp` BTW.

Signed-off-by: Leon Hwang <hffilwlqm@gmail.com>