### PR TITLE
Print drop reason from sk_skb_reason_drop. Catch up with kernel 6.11 changes

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -86,6 +86,7 @@ struct event_t {
 	struct tuple tuple;
 	s64 print_stack_id;
 	u64 param_second;
+	u64 param_third;
 	u32 cpu_id;
 } __attribute__((packed));
 
@@ -504,6 +505,7 @@ kprobe_skb(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip, u64 *
 	event.skb_addr = (u64) skb;
 	event.addr = has_get_func_ip ? bpf_get_func_ip(ctx) : PT_REGS_IP(ctx);
 	event.param_second = PT_REGS_PARM2(ctx);
+	event.param_third = PT_REGS_PARM3(ctx);
 	if (CFG.output_caller)
 		bpf_probe_read_kernel(&event.caller_addr, sizeof(event.caller_addr), (void *)PT_REGS_SP(ctx));
 

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -150,5 +150,6 @@ type Event struct {
 	Tuple         Tuple
 	PrintStackId  int64
 	ParamSecond   uint64
+	ParamThird    uint64
 	CPU           uint32
 }


### PR DESCRIPTION
This commit extracts a drop reason from sk_skb_reason_drop(), and prints it when sk_skb_drop_reason() is called.

This function was introduced in kernel v6.11-rc1. At the same time, kfree_skb_reason()   became an inline helper which just calls  sk_skb_reason_drop().
See: https://github.com/torvalds/linux/commit/ba8de796baf4bdc03530774fb284fe3c97875566

Summary of changes:
- bpf: teach kprobe_skb() to capture the 3rd function argument in the event map
-  go: teach getKFreeSKBReasons() to cope with changes to kfree_skb_reason and introduction of sk_skb_reason_drop() in kernel 
-  go: teach getOutFuncName() about sk_skb_reason_drop() 