### PR TITLE
Improve --filter-track-bpf-helpers

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -433,13 +433,13 @@ set_output(void *ctx, struct sk_buff *skb, struct event_t *event) {
 }
 
 static __noinline bool
-handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_stackid) {
+handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_stackid, const bool is_kprobe) {
 	u8 tracked_by;
 	u64 skb_addr = (u64) skb;
 	u64 skb_head = (u64) BPF_CORE_READ(skb, head);
 	u64 stackid;
 
-	if (cfg->track_skb_by_stackid)
+	if (cfg->track_skb_by_stackid && is_kprobe)
 		stackid = _stackid ? *_stackid : get_stackid(ctx);
 
 	if (cfg->is_set) {
@@ -456,7 +456,7 @@ handle_everything(struct sk_buff *skb, void *ctx, struct event_t *event, u64 *_s
 			goto cont;
 		}
 
-		if (cfg->track_skb_by_stackid && bpf_map_lookup_elem(&stackid_skb, &stackid)) {
+		if (cfg->track_skb_by_stackid && is_kprobe && bpf_map_lookup_elem(&stackid_skb, &stackid)) {
 			tracked_by = TRACKED_BY_STACKID;
 			goto cont;
 		}
@@ -478,7 +478,7 @@ cont:
 			bpf_map_update_elem(&xdp_dhs_skb_heads, &skb_head, &skb_addr, BPF_ANY);
 	}
 
-	if (cfg->track_skb_by_stackid && tracked_by != TRACKED_BY_STACKID) {
+	if (cfg->track_skb_by_stackid && is_kprobe && tracked_by != TRACKED_BY_STACKID) {
 		u64 *old_stackid = bpf_map_lookup_elem(&skb_stackid, &skb);
 		if (old_stackid && *old_stackid != stackid) {
 			bpf_map_delete_elem(&stackid_skb, old_stackid);
@@ -498,7 +498,7 @@ static __always_inline int
 kprobe_skb(struct sk_buff *skb, struct pt_regs *ctx, bool has_get_func_ip, u64 *_stackid) {
 	struct event_t event = {};
 
-	if (!handle_everything(skb, ctx, &event, _stackid))
+	if (!handle_everything(skb, ctx, &event, _stackid, true))
 		return BPF_OK;
 
 	event.skb_addr = (u64) skb;
@@ -594,7 +594,7 @@ SEC("fentry/tc")
 int BPF_PROG(fentry_tc, struct sk_buff *skb) {
 	struct event_t event = {};
 
-	if (!handle_everything(skb, ctx, &event, NULL))
+	if (!handle_everything(skb, ctx, &event, NULL, false))
 		return BPF_OK;
 
 	event.skb_addr = (u64) skb;

--- a/internal/pwru/kprobe.go
+++ b/internal/pwru/kprobe.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -254,6 +255,11 @@ func NewNonSkbFuncsKprober(nonSkbFuncs []string, funcs Funcs, coll *ebpf.Collect
 
 	for _, fn := range nonSkbFuncs {
 		if _, ok := funcs[fn]; ok {
+			continue
+		}
+
+		if strings.HasSuffix(fn, "[bpf]") {
+			// Skip bpf progs
 			continue
 		}
 


### PR DESCRIPTION
It failed to run `./pwru --filter-track-bpf-helpers --filter-trace-tc --filter-func '.*udp.*' --output-limit-lines 10 icmp`, because `fentry` does not support `PT_REGS_FP(ctx)`.

And, skip doing kprobe on bpf progs when run `--filter-track-bpf-helpers`.

Signed-off-by: Leon Hwang <hffilwlqm@gmail.com>