### PR TITLE
README.md: Update Clang/LLVM dependency to 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See [docs/vagrant.md](docs/vagrant.md)
 ### Dependencies
 
 * Go >= 1.16
-* LLVM/clang >= 1.12
+* LLVM/clang >= 12
 * Bison
 * Lex/Flex >= 2.5.31
 


### PR DESCRIPTION
Relying on Clang 1.12 doesn't make sense. Update it to 12.
