### PR TITLE
README: Mention that debugfs is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ after installing an IP tables rule:
 
 `pwru` requires >= 5.3 kernel to run. For `--output-skb` >= 5.9 kernel is required. For `--backend=kprobe-multi` >= 5.18 kernel is required.
 
-`debugfs` has to be mounted in `/sys/kernel/debug`. In case the folder is empty, it can be mounted with:
+`pwru` optionally requires `debugfs`. It has to be mounted in `/sys/kernel/debug`. In case the folder is empty, it can be mounted with:
 
 ```
 mount -t debugfs none /sys/kernel/debug


### PR DESCRIPTION
It's needed for getAvailableFilterFunctions() which is optional.