### PR TITLE
Dockerfile: build arm64 variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM docker.io/library/golang:1.23.1 AS build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.1 AS build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETARCH
 
-RUN apt update && \
-    apt install -y make git clang-15 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
+RUN gcc_pkg=$(if [ "${TARGETARCH}" = "arm64" ]; then echo "aarch64"; else echo "x86-64"; fi)  && \
+    apt update && \
+    apt install -y make git clang-15 llvm curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \
     ln -s /usr/bin/clang-15 /usr/bin/clang
 
 WORKDIR /pwru
 COPY . .
-RUN make local-release
-RUN tar xfv release/pwru-linux-amd64.tar.gz
+RUN ARCHS=${TARGETARCH} make local-release
+RUN tar xfv release/pwru-linux-${TARGETARCH}.tar.gz
 
 FROM busybox
 COPY --from=build /pwru/pwru /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ VERSION=$(shell git describe --tags --always)
 LIBPCAP_ARCH ?= x86_64-unknown-linux-gnu
 # For compiling libpcap and CGO
 CC ?= gcc
+ARCHS ?= amd64 arm64
 
 TEST_TIMEOUT ?= 5s
 .DEFAULT_GOAL := pwru
@@ -41,7 +42,7 @@ release:
 
 ## Build a new release
 local-release: clean
-	ARCHS='amd64 arm64' ./local-release.sh
+	ARCHS='$(ARCHS)' ./local-release.sh
 
 ## Install the GO Binary to the location specified by 'BINDIR'
 install: $(TARGET)

--- a/local-release.sh
+++ b/local-release.sh
@@ -10,7 +10,7 @@ for ARCH in ${ARCHS}; do
         CC=aarch64-linux-gnu-gcc
     else
         LIBPCAP_ARCH=x86_64-unknown-linux-gnu
-        CC=gcc
+        CC=x86_64-linux-gnu-gcc
     fi
 
     make clean


### PR DESCRIPTION
- Closes https://github.com/cilium/pwru/issues/262

Make it possible to build both amd64 and arm64 Docker images. This can be done with:

    docker build --platform linux/amd64,linux/arm64 --tag pwru  .

GHA release workflow only handles GH release artifacts, so the out-of-tree CI job or manual process used to publish images on Docker Hub will have to be updated accordingly.

Also, fix the release script used during image build to support cross-compilation of amd64 on arm64 machines.

(Note that a standalone Docker Engine has to be configured with the containerd snapshotter enabled to build multi-arch images. See https://docs.docker.com/engine/storage/containerd/)