### PR TITLE
bpf: Remove OUTPUT_SKB&HAS_KPROBE_MULTI macros

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -164,7 +164,6 @@ struct {
 	__uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
 } print_stack_map SEC(".maps");
 
-#ifdef OUTPUT_SKB
 struct print_skb_value {
 	u32 len;
 	char str[PRINT_SKB_STR_SIZE];
@@ -197,7 +196,6 @@ struct {
 	__type(key, u64);
 	__type(value, struct print_shinfo_value);
 } print_shinfo_map SEC(".maps");
-#endif
 
 static __always_inline u32
 get_netns(struct sk_buff *skb) {
@@ -344,7 +342,6 @@ sync_fetch_and_add(void *id_map) {
 
 static __always_inline void
 set_skb_btf(struct sk_buff *skb, u64 *event_id) {
-#ifdef OUTPUT_SKB
 	static struct btf_ptr p = {};
 	static struct print_skb_value v = {};
 	u64 id;
@@ -359,12 +356,10 @@ set_skb_btf(struct sk_buff *skb, u64 *event_id) {
 	}
 
 	bpf_map_update_elem(&print_skb_map, event_id, &v, BPF_ANY);
-#endif
 }
 
 static __always_inline void
 set_shinfo_btf(struct sk_buff *skb, u64 *event_id) {
-#ifdef OUTPUT_SKB
 	struct skb_shared_info *shinfo;
 	static struct btf_ptr p = {};
 	static struct print_shinfo_value v = {};
@@ -393,7 +388,6 @@ set_shinfo_btf(struct sk_buff *skb, u64 *event_id) {
 	}
 
 	bpf_map_update_elem(&print_shinfo_map, event_id, &v, BPF_ANY);
-#endif
 }
 
 static __always_inline u64

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -149,6 +149,8 @@ struct config {
 	u8 track_skb_by_stackid: 1;
 	u8 track_xdp: 1;
 	u8 unused: 4;
+	u32 skb_btf_id;
+	u32 shinfo_btf_id;
 } __attribute__((packed));
 
 static volatile const struct config CFG;
@@ -347,7 +349,7 @@ set_skb_btf(struct sk_buff *skb, u64 *event_id) {
 	static struct print_skb_value v = {};
 	u64 id;
 
-	p.type_id = bpf_core_type_id_kernel(struct sk_buff);
+	p.type_id = cfg->skb_btf_id;
 	p.ptr = skb;
 	*event_id = sync_fetch_and_add(&print_skb_id_map);
 
@@ -380,7 +382,7 @@ set_shinfo_btf(struct sk_buff *skb, u64 *event_id) {
 	end = BPF_CORE_READ(skb, end);
 	shinfo = (struct skb_shared_info *)(head + end);
 
-	p.type_id = bpf_core_type_id_kernel(struct skb_shared_info);
+	p.type_id = cfg->shinfo_btf_id;
 	p.ptr = shinfo;
 
 	*event_id = sync_fetch_and_add(&print_shinfo_id_map);

--- a/build.go
+++ b/build.go
@@ -2,9 +2,7 @@
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -DHAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRUWithoutOutputSKB ./bpf/kprobe_pwru.c -- -D HAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRU ./bpf/kprobe_pwru.c -- -DHAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
 
 package main

--- a/build.go
+++ b/build.go
@@ -3,6 +3,5 @@
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbeMultiPWRU ./bpf/kprobe_pwru.c -- -DHAS_KPROBE_MULTI -I./bpf/headers -Wno-address-of-packed-member
 
 package main

--- a/internal/pwru/btf.go
+++ b/internal/pwru/btf.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright Leon Hwang */
+/* Copyright Authors of Cilium */
+
+package pwru
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/btf"
+)
+
+func GetStructBtfID(btfSpec *btf.Spec, structName string) (btf.TypeID, error) {
+	types, err := btfSpec.AnyTypesByName(structName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get BTF types by name %s: %w", structName, err)
+	}
+
+	for _, t := range types {
+		if s, ok := t.(*btf.Struct); ok {
+			return btfSpec.TypeID(s)
+		}
+	}
+
+	return 0, fmt.Errorf("struct %s not found", structName)
+}

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -41,6 +41,9 @@ type FilterCfg struct {
 
 	OutputFlags uint8
 	FilterFlags uint8
+
+	SkbBtfID    uint32
+	ShinfoBtfID uint32
 }
 
 func GetConfig(flags *Flags) (cfg FilterCfg, err error) {

--- a/internal/pwru/kprobe.go
+++ b/internal/pwru/kprobe.go
@@ -201,9 +201,10 @@ func AttachKprobeMulti(ctx context.Context, bar *pb.ProgressBar, kprobes []Kprob
 }
 
 func NewKprober(ctx context.Context, funcs Funcs, coll *ebpf.Collection, a2n Addr2Name, useKprobeMulti bool, batch uint) *kprober {
-	msg := "kprobe"
+	msg, probeMethod := "kprobe", "kprobe"
 	if useKprobeMulti {
 		msg = "kprobe-multi"
+		probeMethod = "kprobe_multi"
 	}
 	log.Printf("Attaching kprobes (via %s)...\n", msg)
 
@@ -213,7 +214,7 @@ func NewKprober(ctx context.Context, funcs Funcs, coll *ebpf.Collection, a2n Add
 	pwruKprobes := make([]Kprobe, 0, len(funcs))
 	funcsByPos := GetFuncsByPos(funcs)
 	for pos, fns := range funcsByPos {
-		fn, ok := coll.Programs[fmt.Sprintf("kprobe_skb_%d", pos)]
+		fn, ok := coll.Programs[fmt.Sprintf("%s_skb_%d", probeMethod, pos)]
 		if ok {
 			pwruKprobes = append(pwruKprobes, Kprobe{HookFuncs: fns, Prog: fn})
 		} else {

--- a/internal/pwru/kprobe.go
+++ b/internal/pwru/kprobe.go
@@ -239,7 +239,7 @@ func NewKprober(ctx context.Context, funcs Funcs, coll *ebpf.Collection, a2n Add
 	bar.Finish()
 	select {
 	case <-ctx.Done():
-		return nil
+		return &k
 	default:
 	}
 	log.Printf("Attached (ignored %d)\n", ignored)

--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -194,3 +194,22 @@ func HaveAvailableFilterFunctions() bool {
 	_, err := getAvailableFilterFunctions()
 	return err == nil
 }
+
+func HaveSnprintfBtf(kernelBtf *btf.Spec) bool {
+	types, err := kernelBtf.AnyTypesByName("bpf_func_id")
+	if err != nil {
+		return false
+	}
+
+	for _, t := range types {
+		if enum, ok := t.(*btf.Enum); ok {
+			for _, v := range enum.Values {
+				if v.Name == "BPF_FUNC_snprintf_btf" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -119,15 +119,19 @@ func main() {
 	opts.Programs.LogLevel = ebpf.LogLevelInstruction
 	opts.Programs.LogSize = ebpf.DefaultVerifierLogSize * 100
 
-	var bpfSpec *ebpf.CollectionSpec
-	switch {
-	case (flags.OutputSkb || flags.OutputShinfo) && useKprobeMulti:
-		bpfSpec, err = LoadKProbeMultiPWRU()
-	default:
-		bpfSpec, err = LoadKProbePWRU()
-	}
+	bpfSpec, err := LoadKProbePWRU()
 	if err != nil {
 		log.Fatalf("Failed to load bpf spec: %v", err)
+	}
+
+	if useKprobeMulti {
+		for i := 1; i <= 5; i++ {
+			delete(bpfSpec.Programs, fmt.Sprintf("kprobe_skb_%d", i))
+		}
+	} else {
+		for i := 1; i <= 5; i++ {
+			delete(bpfSpec.Programs, fmt.Sprintf("kprobe_multi_skb_%d", i))
+		}
 	}
 
 	for name, program := range bpfSpec.Programs {

--- a/main.go
+++ b/main.go
@@ -152,7 +152,18 @@ func main() {
 		}
 	}
 
+	skbBtfID, err := pwru.GetStructBtfID(btfSpec, "sk_buff")
+	if err != nil {
+		log.Fatalf("Failed to get BTF ID for sk_buff: %v", err)
+	}
+	shinfoBtfID, err := pwru.GetStructBtfID(btfSpec, "skb_shared_info")
+	if err != nil {
+		log.Fatalf("Failed to get BTF ID for skb_shared_info: %v", err)
+	}
+
 	pwruConfig, err := pwru.GetConfig(&flags)
+	pwruConfig.SkbBtfID = uint32(skbBtfID)
+	pwruConfig.ShinfoBtfID = uint32(shinfoBtfID)
 	if err != nil {
 		log.Fatalf("Failed to get pwru config: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,10 @@ func main() {
 		log.Fatalf("Failed to load BTF spec: %s", err)
 	}
 
+	if (flags.OutputSkb || flags.OutputShinfo) && !pwru.HaveSnprintfBtf(btfSpec) {
+		log.Fatal("Unsupported to output skb or shinfo because bpf_snprintf_btf() is unavailable")
+	}
+
 	if flags.AllKMods {
 		files, err := os.ReadDir("/sys/kernel/btf")
 		if err != nil {
@@ -119,12 +123,8 @@ func main() {
 	switch {
 	case (flags.OutputSkb || flags.OutputShinfo) && useKprobeMulti:
 		bpfSpec, err = LoadKProbeMultiPWRU()
-	case flags.OutputSkb || flags.OutputShinfo:
-		bpfSpec, err = LoadKProbePWRU()
-	case useKprobeMulti:
-		bpfSpec, err = LoadKProbeMultiPWRUWithoutOutputSKB()
 	default:
-		bpfSpec, err = LoadKProbePWRUWithoutOutputSKB()
+		bpfSpec, err = LoadKProbePWRU()
 	}
 	if err != nil {
 		log.Fatalf("Failed to load bpf spec: %v", err)


### PR DESCRIPTION
When call set_skb_btf() or set_shinfo_btf(), these functions are protected by constant CFG.

Then, while loading kprobe_pwru into kernel, if no --output-skb/--output-skb-shared-info, set_skb_btf()/set_shinfo_btf() won't be verified. Next, these unreachable code will be eliminated by verifier.