### PR TITLE
Output TCP flags alongside tuple

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -64,7 +64,7 @@ struct tuple {
 	u16 dport;
 	u16 l3_proto;
 	u8 l4_proto;
-	u8 pad;
+	u8 tcp_flags;
 } __attribute__((packed));
 
 enum event_type {
@@ -313,6 +313,7 @@ __set_tuple(struct tuple *tpl, void *data, u16 l3_off, bool is_ipv4) {
 		struct tcphdr *tcp = (struct tcphdr *) (data + l4_off);
 		tpl->sport= BPF_CORE_READ(tcp, source);
 		tpl->dport= BPF_CORE_READ(tcp, dest);
+		bpf_probe_read_kernel(&tpl->tcp_flags, sizeof(tpl->tcp_flags), (void *)tcp + offsetof(struct tcphdr, window) - 1);
 	} else if (tpl->l4_proto == IPPROTO_UDP) {
 		struct udphdr *udp = (struct udphdr *) (data + l4_off);
 		tpl->sport= BPF_CORE_READ(udp, source);


### PR DESCRIPTION
It will be helpful to check receiving a RST packet when fail to run `telnet`.

```bash
# ./pwru --filter-func '.*tcp.*' tcp and host 192.168.241.1 and port 8080
2024/12/06 14:30:17 Attaching kprobes (via kprobe-multi)...
146 / 146 [------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s
2024/12/06 14:30:17 Attached (ignored 0)
2024/12/06 14:30:17 Listening for events..
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   __sk_buff->cb[]                                          TUPLE FUNC
0xffff91e7c90a98e8 6   <empty>:0        4026531840 0            ens33:2      0x0800 1500  74    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.133:32956->192.168.241.1:8080(tcp:SYN) tcp_wfree
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 1500  46    [0x00000000,0x00000000,0x00000014,0x00000006,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp4_gro_receive
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 1500  46    [0x00000000,0x00000000,0x00000014,0x00000006,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_gro_receive
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 1500  40    [0x00000000,0x00000000,0x00000000,0x00000000,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_v4_early_demux
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 20    [0x00000000,0x00000000,0x00000000,0x00000000,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_v4_rcv
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 20    [0x00000000,0x00000000,0x00000000,0x00000000,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_filter
0xffff91e7cf0a3e00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 20    [0x00000000,0x00000000,0x00000000,0x00000000,0x00060001] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_v4_fill_cb
0xffff91e7cf0a3e00 6   <empty>:0        0          0               0         0x0800 65536 20    [0x00000000,0x04000014,0x80E6EBB0,0x00000000,0x00000002] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_v4_do_rcv
0xffff91e7cf0a3e00 6   <empty>:0        0          0               0         0x0800 65536 20    [0x00000000,0x04000014,0x80E6EBB0,0x00000000,0x00000002] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_rcv_state_process
0xffff91e7cf0a3e00 6   <empty>:0        0          0               0         0x0800 65536 20    [0x00000000,0x04000014,0x80E6EBB0,0x00000000,0x00000002] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_rcv_synsent_state_process
0xffff91e7cf0a3e00 6   <empty>:0        0          0               0         0x0800 65536 20    [0x00000000,0x04000014,0x80E6EBB0,0x00000000,0x00000002] 192.168.241.1:8080->192.168.241.133:32956(tcp:RST|ACK) tcp_reset
^C2024/12/06 14:30:22 Received signal, exiting program..
2024/12/06 14:30:22 Detaching kprobes...
4 / 4 [---------------------------------------------------------------------------------------------------------------------------------------] 100.00% 22 p/s
```