### PR TITLE
Introduce two enhancements for func IP

### DIFF
--- a/internal/pwru/bpf_prog.go
+++ b/internal/pwru/bpf_prog.go
@@ -13,8 +13,6 @@ import (
 
 var errNotFound = errors.New("not found")
 
-type BpfProgName2Addr map[string]uint64
-
 func listBpfProgs(typ ebpf.ProgramType) ([]*ebpf.Program, error) {
 	var (
 		id  ebpf.ProgramID
@@ -42,7 +40,7 @@ func listBpfProgs(typ ebpf.ProgramType) ([]*ebpf.Program, error) {
 	return progs, nil
 }
 
-func getBpfProgInfo(prog *ebpf.Program) (entryFuncName, progName, tag string, err error) {
+func getBpfProgInfo(prog *ebpf.Program) (entryFuncName string, err error) {
 	info, err := prog.Info()
 	if err != nil {
 		err = fmt.Errorf("failed to get program info: %w", err)
@@ -67,7 +65,7 @@ func getBpfProgInfo(prog *ebpf.Program) (entryFuncName, progName, tag string, er
 	for _, insn := range insns {
 		sym := insn.Symbol()
 		if sym != "" {
-			return sym, info.Name, info.Tag, nil
+			return sym, nil
 		}
 	}
 

--- a/internal/pwru/endbr.go
+++ b/internal/pwru/endbr.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2024 Authors of Cilium */
+/* Copyright 2025 Leon Hwang */
+
+package pwru
+
+import (
+	"encoding/binary"
+
+	"github.com/cilium/ebpf"
+)
+
+// The following genEndbrPoison() and isEndbrInsn() functions are taken from the
+// kernel's arch/x86/include/asm/ibt.h file.
+
+func genEndbrPoison() uint32 {
+	// 4 byte NOP that isn't NOP4 (in fact it is OSP NOP3), such that it
+	// will be unique to (former) ENDBR sites.
+	return 0x001f0f66 /* osp nopl (%rax) */
+}
+
+func isEndbrInsn(val uint32) bool {
+	const endbr64 uint32 = 0xfa1e0ff3
+	const endbr32 uint32 = 0xfb1e0ff3
+
+	if val == genEndbrPoison() {
+		return true
+	}
+
+	val &= ^uint32(0x01000000) /* ENDBR32 -> ENDBR64 */
+	return val == endbr64
+}
+
+func haveEndbrInsn(prog *ebpf.Program) (bool, error) {
+	info, err := prog.Info()
+	if err != nil {
+		return false, err
+	}
+
+	jitedInsns, ok := info.JitedInsns()
+	if !ok || len(jitedInsns) < 4 {
+		return false, nil
+	}
+
+	u32 := binary.NativeEndian.Uint32(jitedInsns[:4])
+	return isEndbrInsn(u32), nil
+}

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	}
 	// If --filter-trace-tc/--filter-trace-xdp, it's to retrieve and print bpf
 	// prog's name.
-	addr2name, name2addr, err := pwru.ParseKallsyms(funcs, flags.OutputStack ||
+	addr2name, err := pwru.ParseKallsyms(funcs, flags.OutputStack ||
 		len(flags.KMods) != 0 || flags.FilterTraceTc || flags.FilterTraceXdp ||
 		len(flags.FilterNonSkbFuncs) > 0 || flags.OutputCaller || flags.FilterTrackBpfHelpers)
 	if err != nil {
@@ -235,14 +235,14 @@ func main() {
 
 	traceTc := false
 	if flags.FilterTraceTc {
-		t := pwru.TraceTC(coll, bpfSpecFentryTc, &opts, flags.OutputSkb, flags.OutputShinfo, name2addr)
+		t := pwru.TraceTC(coll, bpfSpecFentryTc, &opts)
 		defer t.Detach()
 		traceTc = t.HaveTracing()
 	}
 
 	traceXdp := false
 	if flags.FilterTraceXdp {
-		t := pwru.TraceXDP(coll, bpfSpecFentryXdp, &opts, flags.OutputSkb, flags.OutputShinfo, name2addr)
+		t := pwru.TraceXDP(coll, bpfSpecFentryXdp, &opts)
 		defer t.Detach()
 		traceXdp = t.HaveTracing()
 	}


### PR DESCRIPTION
I encountered the following error days ago.

```Go
failed to trace TC progs: failed to trace bpf progs: failed to find address for function pod_XXX of bpf prog SchedCLS(pod_XXX)#108
```

Then, I realize that we have to improve getting func IP when trace bpf progs.

With commit 55bdaac5dea0 ("Fix tracing tc-bpf with --filter-track-skb-by-stackid") and my blog [Debug a tailcall BUG with fentry](https://asphaltt.github.io/post/ebpf-talk-138-debug-tailcall-bug-with-fentry/), I think it's able to get tracee IP when trace bpf progs.

Then, let me introduce our own `get_func_ip()` helper for tracing to get tracee IP.

Next, in 'output.go', it's incorrect to get func name when output in JSON format.

Why not correct func IP in bpf in order to make sure `event.addr` is correct always?

To achieve it, let us do `- 1` for kprobe and `- 4` for endbr in 'kprobe_pwru.c'. As a result, introduce `get_addr()` function for **kprobe**, **kprobe-multi**, **fentry** and **fexit**.

BTW, clean some Go code that was used for tracing bpf progs.

---

- [x] `get_func_ip()` must be compatible on arm64

Test on arm64:

```bash
# ./pwru --backend kprobe --filter-trace-tc --filter-trace-xdp --output-meta --output-tuple --filter-func '.*icmp.*' icmp
0xffff80008000b938 1   ping:363         4026531840 0              lo:1       0x0000 65536 98    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) bpf_prog_3b185187f1855c4c_dummy[bpf](xdp)
0xffff0000c1ee5200 1   <empty>:363      4026531840 0              lo:1       0x0800 65536 64    [0x00000000,0x00000000,0x00000000,0x00000100,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) icmp_rcv
0xffff0000c1ee5200 1   <empty>:363      4026531840 0              lo:1       0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000100,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) icmp_echo
0xffff0000c1ee5200 1   <empty>:363      4026531840 0              lo:1       0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000100,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) icmp_reply
0xffff80008000b938 1   <empty>:363      4026531840 0              lo:1       0x0000 65536 98    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) bpf_prog_3b185187f1855c4c_dummy[bpf](xdp)
0xffff0000c1ee5300 1   <empty>:363      4026531840 0              lo:1       0x0800 65536 64    [0x00000000,0x00000000,0x00000000,0x00000100,0x00000000] 127.0.0.1:0->127.0.0.1:0(icmp) icmp_rcv
```

---

Test on amd64:

```bash
# ./pwru --backend kprobe --filter-trace-tc --filter-trace-xdp --output-meta --output-tuple --filter-func '.*icmp.*' icmp
0xffffaab500600b00 6   <empty>:0        4026531840 0            ens33:2      0x0000 1500  98    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) bpf_prog_3b185187f1855c4c_dummy[bpf](xdp)
0xffff9097a49d1a00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 64    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_rcv
0xffff9097a49d1a00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_echo
0xffff9097a49d1a00 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_reply
```
