### PR TITLE
Enable kprobe-multi for kmods by default

### DIFF
--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -56,11 +56,9 @@ func GetFuncs(pattern string, spec *btf.Spec, kmods []string, kprobeMulti bool) 
 	}
 
 	var availableFuncs map[string]struct{}
-	if kprobeMulti {
-		availableFuncs, err = getAvailableFilterFunctions()
-		if err != nil {
-			log.Printf("Failed to retrieve available ftrace functions (is /sys/kernel/debug/tracing mounted?): %s", err)
-		}
+	availableFuncs, err = getAvailableFilterFunctions()
+	if err != nil {
+		log.Printf("Failed to retrieve available ftrace functions (is /sys/kernel/debug/tracing mounted?): %s", err)
 	}
 
 	iters := []iterator{{"", spec.Iterate()}}
@@ -93,14 +91,12 @@ func GetFuncs(pattern string, spec *btf.Spec, kmods []string, kprobeMulti bool) 
 				continue
 			}
 
-			if kprobeMulti {
-				availableFnName := fnName
-				if it.kmod != "" {
-					availableFnName = fmt.Sprintf("%s [%s]", fnName, it.kmod)
-				}
-				if _, ok := availableFuncs[availableFnName]; !ok {
-					continue
-				}
+			availableFnName := fnName
+			if it.kmod != "" {
+				availableFnName = fmt.Sprintf("%s [%s]", fnName, it.kmod)
+			}
+			if _, ok := availableFuncs[availableFnName]; !ok {
+				continue
 			}
 
 			fnProto := fn.Type.(*btf.FuncProto)

--- a/internal/pwru/utils.go
+++ b/internal/pwru/utils.go
@@ -107,7 +107,7 @@ func GetFuncs(pattern string, spec *btf.Spec, kmods []string, kprobeMulti bool) 
 						if strct.Name == "sk_buff" && i <= 5 {
 							name := fnName
 							if kprobeMulti && it.kmod != "" {
-								name = fmt.Sprintf("%s [%s]", fnName, it.kmod)
+								name = fmt.Sprintf("%s[%s]", fnName, it.kmod)
 							}
 							funcs[name] = i
 							continue

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	// Until https://lore.kernel.org/bpf/20221025134148.3300700-1-jolsa@kernel.org/
 	// has been backported to the stable, kprobe-multi cannot be used when attaching
 	// to kmods.
-	if flags.Backend == "" && len(flags.KMods) == 0 {
+	if flags.Backend == "" {
 		useKprobeMulti = pwru.HaveBPFLinkKprobeMulti() && pwru.HaveAvailableFilterFunctions()
 	} else if flags.Backend == pwru.BackendKprobeMulti {
 		useKprobeMulti = true

--- a/main.go
+++ b/main.go
@@ -117,7 +117,6 @@ func main() {
 	var opts ebpf.CollectionOptions
 	opts.Programs.KernelTypes = btfSpec
 	opts.Programs.LogLevel = ebpf.LogLevelInstruction
-	opts.Programs.LogSize = ebpf.DefaultVerifierLogSize * 100
 
 	bpfSpec, err := LoadKProbePWRU()
 	if err != nil {


### PR DESCRIPTION
This commit enables using the kprobe-multi backend for tracing functions in kernel modules by default if supported. Previously that was only possible by specifying the `--backend=kprobe-multi` option.

Fixes #147

