### PR TITLE
Events from kprobe.multi have eventTypeKprobeMulti set in .type

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -31,9 +31,10 @@ import (
 const absoluteTS string = "15:04:05.000"
 
 const (
-	eventTypeKprobe     = 0
-	eventTypeTracingTc  = 1
-	eventTypeTracingXdp = 2
+	eventTypeKprobe = iota
+	eventTypeKprobeMulti
+	eventTypeTracingTc
+	eventTypeTracingXdp
 )
 
 type output struct {
@@ -261,7 +262,7 @@ func getAddrByArch(event *Event, o *output) (addr uint64) {
 	switch runtime.GOARCH {
 	case "amd64":
 		addr = event.Addr
-		if !o.kprobeMulti && event.Type == eventTypeKprobe {
+		if event.Type == eventTypeKprobe {
 			addr -= 1
 		}
 	case "arm64":


### PR DESCRIPTION
Even with --backend kprobe-multi, pwru still uses kprobe for --filter-track-bpf-helpers. This patch makes pwru capable of distinguishing event types in order to adjust addressres for symbol resolution.

Fixes: https://github.com/cilium/pwru/issues/462