### PR TITLE
Fix broken --filter-trace-xdp caused by go-ebpf v0.17.1

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -30,7 +30,7 @@
 const static bool TRUE = true;
 const static u32 ZERO = 0;
 
-volatile const static __u64 BPF_PROG_ADDR = 0;
+volatile const __u64 BPF_PROG_ADDR = 0;
 
 enum {
 	TRACKED_BY_FILTER = (1 << 0),

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -92,10 +92,8 @@ func (t *tracing) traceProg(spec *ebpf.CollectionSpec,
 	}
 
 	spec = spec.Copy()
-	if err := spec.RewriteConstants(map[string]any{
-		"BPF_PROG_ADDR": addr,
-	}); err != nil {
-		return fmt.Errorf("failed to rewrite bpf prog addr: %w", err)
+	if err := spec.Variables["BPF_PROG_ADDR"].Set(addr); err != nil {
+		return fmt.Errorf("failed to set bpf prog addr: %w", err)
 	}
 
 	spec.Programs[tracingName].AttachTarget = prog


### PR DESCRIPTION
Fixes #483 

There're two issue:

One is `BPF_PROG_ADDR` must be set via `spec.Variable`.

Another one is `.bss` map flag must be updated because go-ebpf v0.17.1 set `BPF_F_MMAPABLE` flag to created `.bss` map. As a result, we can reuse `.bss` map.

Here's the test result:

```bash
2025/01/15 15:14:26 Attaching tc-bpf progs...
2025/01/15 15:14:26 Attaching xdp progs...
2025/01/15 15:14:26 Attaching kprobes (via kprobe)...
29 / 29 [--------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s
2025/01/15 15:14:26 Attached (ignored 0)
2025/01/15 15:14:26 Listening for events..
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   __sk_buff->cb[]                                          TUPLE FUNC
0xffffb5dd40600b00 6   <empty>:0        4026531840 0            ens33:2      0x0000 1500  98    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) bpf_prog_3b185187f1855c4c_dummy[bpf](xdp)
0xffff995b7756d400 6   <empty>:0        4026531840 0            ens33:2      0x0800 1500  98    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) bpf_prog_e20a685998fd41c8_entry1[bpf](tc)
0xffff995b7756d400 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 64    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_rcv
0xffff995b7756d400 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_echo
0xffff995b7756d400 6   <empty>:0        4026531840 0            ens33:2      0x0800 65536 56    [0x00000000,0x00000000,0x00000000,0x00000000,0x00000000] 192.168.241.1:0->192.168.241.133:0(icmp) icmp_reply
^C2025/01/15 15:14:30 Received signal, exiting program..
2025/01/15 15:14:30 Detaching kprobes...
29 / 29 [------------------------------------------------------------------------------------------------------------------------------------] 100.00% 132 p/s
```

And there's only one `.bss` map:

```bash
# bpftool m | grep -c .bss
1
```