### PR TITLE
fix missing constant from .rodata in --filter-trace-tc

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -30,7 +30,7 @@
 const static bool TRUE = true;
 const static u32 ZERO = 0;
 
-volatile const static __u64 BPF_PROG_ADDR = 0;
+volatile const __u64 BPF_PROG_ADDR = 0;
 
 enum {
 	TRACKED_BY_FILTER = (1 << 0),

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -92,9 +92,7 @@ func (t *tracing) traceProg(spec *ebpf.CollectionSpec,
 	}
 
 	spec = spec.Copy()
-	if err := spec.RewriteConstants(map[string]any{
-		"BPF_PROG_ADDR": addr,
-	}); err != nil {
+	if err := spec.Variables["BPF_PROG_ADDR"].Set(addr); err != nil {
 		return fmt.Errorf("failed to rewrite bpf prog addr: %w", err)
 	}
 
@@ -134,6 +132,7 @@ func (t *tracing) trace(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
 	// with the kprobes.
 	replacedMaps := maps.Clone(coll.Maps)
 	delete(replacedMaps, ".rodata")
+	delete(replacedMaps, ".bss")
 	opts.MapReplacements = replacedMaps
 
 	var errg errgroup.Group


### PR DESCRIPTION
While running pwru with `--filter-trace-tc`, I received the following error:

```bash
Attaching tc-bpf progs...
failed to trace TC progs: failed to trace bpf progs: failed to rewrite bpf prog addr: rewrite constants: some constants are missing from .rodata: BPF_PROG_ADDR
```

I then decided to drop the static identifier from BPF_PROG_ADDR and switch from RewriteConstants to the new global variable API. However, this was not enough, since I started receiving:

```bash
Attaching tc-bpf progs...
failed to trace TC progs: failed to trace bpf progs: failed to load objects:
using replacement map .bss: Flags: 1024 changed to 0: map spec is incompatible with existing map
```

Therefore, I've added a line to delete also `.bss` maps other than `.rodata` while rewriting specs. This enables back running pwru with `--filter-trace-tc`.

Fixes: #488

(This will be my 1st pwru PR, please any kind of suggestion/feedback is very welcome)