### PR TITLE
gh/workflows: Set up traffic before running pwru

### DIFF
--- a/.github/actions/pwru-test/action.yaml
+++ b/.github/actions/pwru-test/action.yaml
@@ -10,7 +10,10 @@ inputs:
   pwru-pcap-filter:
     required: false
     type: string
-  traffic-setup:
+  setup:
+    required: false
+    type: string
+  gen-traffic:
     required: false
     type: string
   expected-output-pattern:
@@ -27,6 +30,8 @@ runs:
         cmd: |
           set -x
 
+          ${{ inputs.setup }}
+
           /host/pwru/pwru \
             --output-tuple \
             --output-file=/tmp/pwru-${{ inputs.test-name }}.log \
@@ -38,7 +43,7 @@ runs:
 
           while [ ! -f /tmp/pwru-${{ inputs.test-name }}.ready ]; do sleep 1; done
 
-          ${{ inputs.traffic-setup }}
+          ${{ inputs.gen-traffic }}
 
           kill \$PWRU_PID
           wait \$PWRU_PID

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,9 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-basic-ipv4
           pwru-pcap-filter: 'dst host 1.0.0.1 and port 8080'
-          traffic-setup: |
+          setup: |
             iptables -w 10 -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.1/32 --dport 8080 -j DROP
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.1:8080 || true
           expected-output-pattern: '1.0.0.1:8080.*(kfree_skb_reason|kfree_skb|sk_skb_reason_drop\b)'
 
@@ -96,8 +97,9 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-basic-ipv6
           pwru-pcap-filter: 'dst host 2606:4700:4700::1001 and port 8080'
-          traffic-setup: |
+          setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1001 --dport 8080 -j DROP
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1001]:8080 || true
           expected-output-pattern: '\[2606:4700:4700::1001\]:8080.*(kfree_skb_reason|kfree_skb|sk_skb_reason_drop\b)'
 
@@ -106,8 +108,9 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-advanced-ipv4
           pwru-pcap-filter: 'tcp[tcpflags] = tcp-syn'
-          traffic-setup: |
+          setup: |
             iptables -w 10 -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.2/32 --dport 8080 -j DROP
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.2:8080 || true
           expected-output-pattern: '1.0.0.2:8080.*(kfree_skb_reason|kfree_skb|sk_skb_reason_drop\b)'
 
@@ -116,8 +119,9 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-advanced-ipv6
           pwru-pcap-filter: 'ip6[53] & 0x3f = 0x2'
-          traffic-setup: |
+          setup: |
             ip6tables -I OUTPUT 1 -m tcp --proto tcp --dst 2606:4700:4700::1002 --dport 8080 -j DROP
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://[2606:4700:4700::1002]:8080 || true
           expected-output-pattern: '\[2606:4700:4700::1002\]:8080.*(kfree_skb_reason|kfree_skb|sk_skb_reason_drop\b)'
 
@@ -126,7 +130,7 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-pcap-filter-stack
           pwru-pcap-filter: '(((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)'
-          traffic-setup: curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.1.1.1 || true; sleep 5
+          gen-traffic: curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.1.1.1 || true; sleep 5
           expected-output-pattern: '1.1.1.1:80'
 
       - name: Test --filter-track-skb
@@ -135,8 +139,9 @@ jobs:
           test-name: ${{ matrix.kernel }}-filter-track-skb
           pwru-flags: --filter-track-skb
           pwru-pcap-filter: dst host 10.10.20.99
-          traffic-setup: |
+          setup: |
             iptables -w 10 -t nat -I OUTPUT 1 -d 10.10.20.99/32 -j DNAT --to-destination 10.10.14.2
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://10.10.20.99:80 || true
           expected-output-pattern: '10.10.14.2:80'
 
@@ -145,7 +150,7 @@ jobs:
         with:
           test-name: ${{ matrix.kernel }}-filter-arp
           pwru-pcap-filter: 'arp and arp[7] = 1 and arp[24]= 169 and arp[25] = 254 and arp[26] = 0 and arp[27] = 1'
-          traffic-setup: |
+          setup: |
             ip net a pwru
             ip l a pwru-veth type veth peer name pwru-veth-peer
             ip l s pwru-veth-peer up
@@ -155,7 +160,7 @@ jobs:
             ip net e pwru ip a a 10.0.0.1 dev pwru-veth
             ip net e pwru ip r a 169.254.0.1 dev pwru-veth
             ip net e pwru ip r a default via 169.254.0.1 dev pwru-veth
-
+          gen-traffic: |
             ping -W1 -c1 10.0.0.1 || true
           expected-output-pattern: 'arp_rcv'
 
@@ -165,7 +170,7 @@ jobs:
           test-name: ${{ matrix.kernel }}-filter-ifname
           pwru-flags: --filter-ifname lo
           pwru-pcap-filter: icmp
-          traffic-setup: |
+          gen-traffic: |
             ping -W1 -c1 127.0.0.1 || true
           expected-output-pattern: 'icmp'
 
@@ -176,8 +181,9 @@ jobs:
           test-name: ${{ matrix.kernel }}-kprobe-multi-basic
           pwru-flags: --backend=kprobe-multi
           pwru-pcap-filter: 'dst host 1.0.0.1 and port 8080'
-          traffic-setup: |
+          setup: |
             iptables -w 10 -I OUTPUT 1 -m tcp --proto tcp --dst 1.0.0.1/32 --dport 8080 -j DROP
+          gen-traffic: |
             curl -vvv -sS --fail --connect-timeout "1" -o /dev/null http://1.0.0.1:8080 || true
           expected-output-pattern: '1.0.0.1:8080.*(kfree_skb_reason|kfree_skb|sk_skb_reason_drop\b)'
 


### PR DESCRIPTION
Needed when running upcoming BPF/XDP tracing tests.