### PR TITLE
Support outputting and filtering by vxlan/geneve tunnel data

### DIFF
--- a/internal/libpcap/inject.go
+++ b/internal/libpcap/inject.go
@@ -17,7 +17,7 @@ func InjectL2Filter(program *ebpf.ProgramSpec, filterExpr string) (err error) {
 	return injectFilter(program, filterExpr, false, false)
 }
 
-func InjectFilters(program *ebpf.ProgramSpec, filterExpr, tunnelFilterExpr string) (err error) {
+func InjectFilters(program *ebpf.ProgramSpec, filterExpr, tunnelFilterExprL2, tunnelFilterExprL3 string) (err error) {
 	if err = injectFilter(program, filterExpr, false, false); err != nil {
 		return
 	}
@@ -28,10 +28,10 @@ func InjectFilters(program *ebpf.ProgramSpec, filterExpr, tunnelFilterExpr strin
 		return injectFilter(program, "__pwru_reject_all__", true, false)
 	}
 	// Attach any tunnel filters.
-	if err := injectFilter(program, tunnelFilterExpr, false, true); err != nil {
+	if err := injectFilter(program, tunnelFilterExprL2, false, true); err != nil {
 		return fmt.Errorf("l2 tunnel filter: %w", err)
 	}
-	if err := injectFilter(program, tunnelFilterExpr, true, true); err != nil {
+	if err := injectFilter(program, tunnelFilterExprL3, true, true); err != nil {
 		return fmt.Errorf("l3 tunnel filter: %w", err)
 	}
 	return nil

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -23,6 +23,7 @@ const (
 	OutputStackMask
 	OutputCallerMask
 	OutputCbMask
+	OutputTunnelMask
 )
 
 const (
@@ -65,6 +66,9 @@ func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	}
 	if flags.OutputTuple {
 		cfg.OutputFlags |= OutputTupleMask
+	}
+	if flags.OutputTunnel {
+		cfg.OutputFlags |= OutputTunnelMask
 	}
 	if flags.OutputStack {
 		cfg.OutputFlags |= OutputStackMask

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -38,7 +38,8 @@ type Flags struct {
 	FilterTrackBpfHelpers   bool
 	FilterIfname            string
 	FilterPcap              string
-	FilterTunnelPcap        string
+	FilterTunnelPcapL2      string
+	FilterTunnelPcapL3      string
 	FilterKprobeBatch       uint
 
 	OutputTS         string
@@ -76,7 +77,8 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 	flag.BoolVar(&f.FilterTrackSkbByStackid, "filter-track-skb-by-stackid", false, "trace a packet even after it is kfreed (e.g., traffic going through bridge)")
 	flag.BoolVar(&f.FilterTraceTc, "filter-trace-tc", false, "trace TC bpf progs")
-	flag.StringVar(&f.FilterTunnelPcap, "filter-tunnel-pcap", "", "pcap expression for vxlan/geneve tunnel (l3)")
+	flag.StringVar(&f.FilterTunnelPcapL2, "filter-tunnel-pcap-l2", "", "pcap expression for vxlan/geneve tunnel (l2)")
+	flag.StringVar(&f.FilterTunnelPcapL3, "filter-tunnel-pcap-l3", "", "pcap expression for vxlan/geneve tunnel (l3)")
 	flag.BoolVar(&f.FilterTraceXdp, "filter-trace-xdp", false, "trace XDP bpf progs")
 	flag.BoolVar(&f.FilterTrackBpfHelpers, "filter-track-bpf-helpers", false, "trace BPF helper functions")
 	flag.StringVar(&f.FilterIfname, "filter-ifname", "", "filter skb ifname in --filter-netns (if not specified, use current netns)")

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -38,6 +38,7 @@ type Flags struct {
 	FilterTrackBpfHelpers   bool
 	FilterIfname            string
 	FilterPcap              string
+	FilterTunnelPcap        string
 	FilterKprobeBatch       uint
 
 	OutputTS         string
@@ -52,6 +53,7 @@ type Flags struct {
 	OutputFile       string
 	OutputJson       bool
 	OutputTCPFlags   bool
+	OutputTunnel     bool
 
 	KMods    []string
 	AllKMods bool
@@ -74,6 +76,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 	flag.BoolVar(&f.FilterTrackSkbByStackid, "filter-track-skb-by-stackid", false, "trace a packet even after it is kfreed (e.g., traffic going through bridge)")
 	flag.BoolVar(&f.FilterTraceTc, "filter-trace-tc", false, "trace TC bpf progs")
+	flag.StringVar(&f.FilterTunnelPcap, "filter-tunnel-pcap", "", "pcap expression for vxlan/geneve tunnel (l3)")
 	flag.BoolVar(&f.FilterTraceXdp, "filter-trace-xdp", false, "trace XDP bpf progs")
 	flag.BoolVar(&f.FilterTrackBpfHelpers, "filter-track-bpf-helpers", false, "trace BPF helper functions")
 	flag.StringVar(&f.FilterIfname, "filter-ifname", "", "filter skb ifname in --filter-netns (if not specified, use current netns)")
@@ -83,6 +86,7 @@ func (f *Flags) SetFlags() {
 	flag.BoolVar(&f.OutputTuple, "output-tuple", true, "print L4 tuple")
 	flag.BoolVar(&f.OutputSkb, "output-skb", false, "print skb")
 	flag.BoolVar(&f.OutputShinfo, "output-skb-shared-info", false, "print skb shared info")
+	flag.BoolVar(&f.OutputTunnel, "output-tunnel", false, "print encapsulated tunnel header data")
 	flag.BoolVar(&f.OutputStack, "output-stack", false, "print stack")
 	flag.BoolVar(&f.OutputCaller, "output-caller", false, "print caller function name")
 	flag.Uint64Var(&f.OutputLimitLines, "output-limit-lines", 0, "exit the program after the number of events has been received/printed")
@@ -178,6 +182,7 @@ type Event struct {
 	PrintShinfoId uint64
 	Meta          Meta
 	Tuple         Tuple
+	TunnelTuple   Tuple
 	PrintStackId  int64
 	ParamSecond   uint64
 	ParamThird    uint64

--- a/main.go
+++ b/main.go
@@ -151,7 +151,9 @@ func main() {
 			continue
 		}
 		if err = libpcap.InjectFilters(program,
-			flags.FilterPcap, flags.FilterTunnelPcap); err != nil {
+			flags.FilterPcap,
+			flags.FilterTunnelPcapL2,
+			flags.FilterTunnelPcapL3); err != nil {
 			log.Fatalf("Failed to inject filter ebpf for %s: %v", name, err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -150,7 +150,8 @@ func main() {
 			}
 			continue
 		}
-		if err = libpcap.InjectFilters(program, flags.FilterPcap); err != nil {
+		if err = libpcap.InjectFilters(program,
+			flags.FilterPcap, flags.FilterTunnelPcap); err != nil {
 			log.Fatalf("Failed to inject filter ebpf for %s: %v", name, err)
 		}
 	}


### PR DESCRIPTION
If the flag is enabled, packets that appear to be vxlan encapsulated will have the filtering function applied. Note: Therefore, to avoid getting non-vxlan traffic you will want to apply a general pcap filter on the vxlan udp ports.

As well, the flag --output-tunnel will result in output of vxlan header data (i.e. flag/vin) as well as inner address tuple.

## Example Output

```bash
sudo ./pwru --output-tuple  --filter-func=udp_queue_rcv_skb  'port 8472' --output-tunnel --filter-tunnel-pcap-l3 'port 8080'  --output-tcp-flags
2025/01/27 16:35:45 Attaching kprobes (via kprobe)...
1 / 1 [-----------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s
2025/01/27 16:35:45 Attached (ignored 0)
2025/01/27 16:35:45 Listening for events..
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC TUNNEL
0xffff0000ea5d7ce8 7   <empty>:2287425  4026532458 0            eth0:353     0x0800 65536 90    172.18.0.5:54806->172.18.0.2:8472(udp) udp_queue_rcv_skb 52:2e:36:8d:11:23 -> ba:44:d8:6c:66:5a 10.244.1.205:36739->10.244.3.122:8080(tcp:SYN)
0xffff00011e41e900 7   <empty>:2287425  4026532646 0            eth0:359     0x0800 65536 90    172.18.0.2:53786->172.18.0.5:8472(udp) udp_queue_rcv_skb 92:53:8f:3a:e7:ef -> 7e:16:77:14:df:0d 10.244.3.122:8080->10.244.1.205:36739(tcp:SYN|ACK)
0xffff00011e41ef00 7   <empty>:2287425  4026532458 0            eth0:353     0x0800 65536 82    172.18.0.5:54806->172.18.0.2:8472(udp) udp_queue_rcv_skb 52:2e:36:8d:11:23 -> ba:44:d8:6c:66:5a 10.244.1.205:36739->10.244.3.122:8080(tcp:ACK)
0xffff0000ea5d7ce8 7   <empty>:2287425  4026532458 0            eth0:353     0x0800 65536 82    172.18.0.5:54806->172.18.0.2:8472(udp) udp_queue_rcv_skb 52:2e:36:8d:11:23 -> ba:44:d8:6c:66:5a 10.244.1.205:36739->10.244.3.122:8080(tcp:FIN|ACK)
0xffff0000e9b75ce8 6   node:2108761     4026532646 0            eth0:359     0x0800 65536 82    172.18.0.2:53786->172.18.0.5:8472(udp) udp_queue_rcv_skb 92:53:8f:3a:e7:ef -> 7e:16:77:14:df:0d 10.244.3.122:8080->10.244.1.205:36739(tcp:FIN|ACK)

```

## Follow up work
- [x] Add support for Geneve
- [ ] Add support for ip encap ip