### PR TITLE
Move Contributing to a separate file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+`pwru` is an open source project. The userspace code is licensed under [Apache-2.0](LICENSE), while the BPF under [BSD 2-Clause](bpf/LICENSE.BSD-2-Clause) and [GPL-2.0](bpf/LICENSE.GPL-2.0). Everybody is welcome to contribute. Contributors are required to follow the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) and must adhere to the [Developer Certificate of Origin](https://developercertificate.org/) by adding a Signed-off-by line to their commit messages.
+
+## Getting Started
+
+- Read the [README](https://github.com/cilium/pwru#readme) to understand how `pwru` works and its use cases.
+- Check out the [issues list](https://github.com/cilium/pwru/issues) for open tasks, especially those labeled `good first issue`.
+
+## Development Guidelines
+
+- Follow Cilium's general [Developer Guide](https://docs.cilium.io/en/stable/contributing/development/) for coding standards and best practices.
+- Before submitting a pull request, review the [Code Review Guidelines](https://docs.cilium.io/en/stable/contributing/code-reviews/).
+- Ensure your changes are well-tested and documented.
+
+## Developing  
+
+If you're looking to contribute code to `pwru`, you'll need to set up your development environment with the required dependencies and build the project locally.  
+
+### Dependencies  
+
+Ensure you have the following installed:  
+
+- Go >= 1.16  
+- LLVM/Clang >= 12  
+- Bison  
+- Lex/Flex >= 2.5.31  
+
+### Building  
+
+To build `pwru`, simply run:  
+
+```
+make
+```
+
+Alternatively, you can build it within a Docker container:
+
+```
+make release
+```
+
+## Contributor Ladder  
+
+Cilium has a well-defined [contributor ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md) to help community members grow both responsibilities and privileges in the ecosystem. This ladder outlines the path from an occasional contributor to a committer, detailing expectations at each stage. Most contributors start at the community level and progress as they become more engaged in the project. We encourage you to take an active role, and the community is here to support you on this journey.  
+
+Becoming a [Cilium organization member](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member) grants you additional privileges, such as the ability to trigger CI runs. If you're contributing regularly to `pwru`, consider joining the [pwru team](https://github.com/cilium/community/blob/main/ladder/teams/pwru.yaml) to help review code and accelerate development. Your contributions play a vital role in improving the project, and we'd love to have you more involved!
+
+## Community
+
+Join the Cilium community for discussions:
+
+Slack: [Cilium Slack](https://slack.cilium.io/) in #pwru
+GitHub Discussions: [cilium/pwru discussions](https://github.com/cilium/pwru/discussions)
+
+We appreciate your contributions to `pwru` and look forward to your involvement!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ Ensure that all commits have [Developer Certificate of Origin](https://developer
 
 ## Contributor Ladder  
 
-Cilium has a well-defined [contributor ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md) to help community members grow both responsibilities and privileges in the ecosystem. This ladder outlines the path from an occasional contributor to a committer, detailing expectations at each stage. Most contributors start at the community level and progress as they become more engaged in the project. We encourage you to take an active role, and the community is here to support you on this journey.  
+The Cilium project has a well-defined [contributor ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md) to help community members grow both responsibilities and privileges in the project ecosystem. This ladder outlines the path from an occasional contributor to a committer, detailing expectations at each stage. Most contributors start at the community level in a sub-project and progress as they become more engaged in the project ecosystem. We encourage you to take an active role, and the community is here to support you on this journey.  
 
-Becoming a [Cilium organization member](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member) grants you additional privileges, such as the ability to trigger CI runs. If you're contributing regularly to `pwru`, consider joining the [pwru team](https://github.com/cilium/community/blob/main/ladder/teams/pwru.yaml) to help review code and accelerate development. Your contributions play a vital role in improving the project, and we'd love to have you more involved!
+Becoming a [Cilium organization member](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member) grants you additional privileges across the project ecosystem, such as the ability to leave reviews on a PR or trigger CI runs. If you're contributing regularly to `pwru`, consider joining the [pwru team](https://github.com/cilium/community/blob/main/ladder/teams/pwru.yaml) to help review code and accelerate development. Your contributions play a vital role in improving the project, and we'd love to have you more involved!
 
 ## Community
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,6 @@ Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) and mu
 - Read the [README](https://github.com/cilium/pwru#readme) to understand how `pwru` works and its use cases.
 - Check out the [issues list](https://github.com/cilium/pwru/issues) for open tasks, especially those labeled `good first issue`.
 
-## Development Guidelines
-
-- Follow Cilium's general [Developer Guide](https://docs.cilium.io/en/stable/contributing/development/) for coding standards and best practices.
-- Before submitting a pull request, review the [Code Review Guidelines](https://docs.cilium.io/en/stable/contributing/code-reviews/).
-- Ensure your changes are well-tested and documented.
-
 ## Developing  
 
 If you're looking to contribute code to `pwru`, you'll need to set up your development environment with the required dependencies and build the project locally.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 `pwru` is an open source project. The userspace code is licensed under [Apache-2.0](LICENSE), while the BPF under [BSD 2-Clause](bpf/LICENSE.BSD-2-Clause) and [GPL-2.0](bpf/LICENSE.GPL-2.0). Everybody is welcome to contribute. Contributors are required to follow the [CNCF Code of
-Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) and must adhere to the [Developer Certificate of Origin](https://developercertificate.org/) by adding a Signed-off-by line to their commit messages.
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 ## Getting Started
 
@@ -34,6 +34,10 @@ Alternatively, you can build it within a Docker container:
 ```
 make release
 ```
+
+### Sign-off
+
+Ensure that all commits have [Developer Certificate of Origin](https://developercertificate.org/) by adding a [Signed-off-by line to your commit messages](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin).
 
 ## Contributor Ladder  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,37 +7,7 @@ Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 - Read the [README](https://github.com/cilium/pwru#readme) to understand how `pwru` works and its use cases.
 - Check out the [issues list](https://github.com/cilium/pwru/issues) for open tasks, especially those labeled `good first issue`.
-
-## Developing  
-
-If you're looking to contribute code to `pwru`, you'll need to set up your development environment with the required dependencies and build the project locally.  
-
-### Dependencies  
-
-Ensure you have the following installed:  
-
-- Go >= 1.16  
-- LLVM/Clang >= 12  
-- Bison  
-- Lex/Flex >= 2.5.31  
-
-### Building  
-
-To build `pwru`, simply run:  
-
-```
-make
-```
-
-Alternatively, you can build it within a Docker container:
-
-```
-make release
-```
-
-### Sign-off
-
-Ensure that all commits have [Developer Certificate of Origin](https://developercertificate.org/) by adding a [Signed-off-by line to your commit messages](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin).
+- Set up your [development](https://github.com/cilium/pwru?tab=readme-ov-file#developing) environment with the required dependencies and build the project locally.
 
 ## Contributor Ladder  
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Alternatively, you can build in the Docker container:
 make release
 ```
 
+### Sign-off
+
+Ensure that all commits have [Developer Certificate of Origin](https://developercertificate.org/) by adding a [Signed-off-by line to your commit messages](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin).
+
 ## Community
 
 Join the `#pwru` [Slack channel](https://slack.cilium.io) to chat with

--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ kubectl logs -f pwru
 
 See [docs/vagrant.md](docs/vagrant.md)
 
+## Developing
+
+### Dependencies
+
+* Go >= 1.16
+* LLVM/clang >= 12
+* Bison
+* Lex/Flex >= 2.5.31
+
+### Building
+
+```
+make
+```
+
+Alternatively, you can build in the Docker container:
+
+```
+make release
+```
+
 ## Community
 
 Join the `#pwru` [Slack channel](https://slack.cilium.io) to chat with

--- a/README.md
+++ b/README.md
@@ -140,38 +140,6 @@ kubectl logs -f pwru
 
 See [docs/vagrant.md](docs/vagrant.md)
 
-## Developing
-
-### Dependencies
-
-* Go >= 1.16
-* LLVM/clang >= 12
-* Bison
-* Lex/Flex >= 2.5.31
-
-### Building
-
-```
-make
-```
-
-Alternatively, you can build in the Docker container:
-
-```
-make release
-```
-
-## Contributing
-
-`pwru` is an open source project. The userspace code is licensed under
-[Apache-2.0](LICENSE), while the BPF under [BSD 2-Clause](bpf/LICENSE.BSD-2-Clause)
-and [GPL-2.0](bpf/LICENSE.GPL-2.0). Everybody is welcome to contribute.
-Contributors are required to follow the [Contributor Covenant Code of
-Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) and
-must adhere to the [Developer Certificate of
-Origin](https://developercertificate.org/) by adding a Signed-off-by line to
-their commit messages.
-
 ## Community
 
 Join the `#pwru` [Slack channel](https://slack.cilium.io) to chat with


### PR DESCRIPTION
Moving the developing and contributing sections out of the main README into a separate file like most projects