### PR TITLE
CI: Fix Failures: Bump LVM action version to latest release.

### DIFF
--- a/.github/actions/pwru-test/action.yaml
+++ b/.github/actions/pwru-test/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: PWRU test
-      uses: cilium/little-vm-helper@9d758b756305e83718a51b792a5aeabd022a39ec # v0.0.16
+      uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
       with:
         provision: 'false'
         cmd: |
@@ -52,7 +52,7 @@ runs:
 
     - name: Fetch artifacts from LVH VM
       if: ${{ !success() }}
-      uses: cilium/little-vm-helper@9d758b756305e83718a51b792a5aeabd022a39ec # v0.0.16
+      uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
       with:
         provision: 'false'
         cmd: |
@@ -61,7 +61,7 @@ runs:
 
     - name: Upload artifacts
       if: ${{ !success() }}
-      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{ inputs.test-name }}
         path: ./logs/${{ inputs.test-name }}/pwru-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           echo "vsn=${major}${minor}" >> "$GITHUB_OUTPUT"
 
       - name: Provision LVH VMs
-        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
         with:
           test-name: pwru-test
           image-version: ${{ matrix.kernel }}
@@ -225,7 +225,7 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ !success() }}
-        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
         with:
           provision: 'false'
           cmd: |

--- a/actions/pwru-log/action.yaml
+++ b/actions/pwru-log/action.yaml
@@ -20,7 +20,7 @@ runs:
         done
 
     - name: Upload PWRU logs
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: pwru-log
         path: pwru*.log


### PR DESCRIPTION
Previous version now fails with:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 13aacd865c20de90d75de3b17ebe84f7a17d57d2`
```