### PR TITLE
go.mod: Bump to 1.24.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /pwru \
-		--volume `pwd`:/pwru docker.io/library/golang:1.23.1 \
+		--volume `pwd`:/pwru docker.io/library/golang:1.24.1 \
 		sh -c "apt update && apt install -y make git clang-15 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
 			ln -s /usr/bin/clang-15 /usr/bin/clang && \
 			git config --global --add safe.directory /pwru && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/pwru
 
-go 1.23.1
+go 1.24.1
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7

--- a/test-app/go.mod
+++ b/test-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/pwru/test-app
 
-go 1.23.3
+go 1.24.1
 
 require github.com/cilium/ebpf v0.17.1
 


### PR DESCRIPTION
To resolve confused Renovate's "go mod tidy" (in the GH build workflow we compare "go mod tidy"'s output against go 1.23.1).