### PR TITLE
Support output tuple for 802.1Q

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -384,6 +384,9 @@ set_tuple(struct sk_buff *skb, struct tuple *tpl) {
 	void *skb_head = BPF_CORE_READ(skb, head);
 	u16 l3_off = BPF_CORE_READ(skb, network_header);
 
+	if (BPF_CORE_READ(skb, protocol) == bpf_ntohs(ETH_P_8021Q))
+		l3_off += sizeof(struct vlan_hdr);
+
 	struct iphdr *l3_hdr = (struct iphdr *) (skb_head + l3_off);
 	u8 ip_vsn = BPF_CORE_READ_BITFIELD_PROBED(l3_hdr, version);
 


### PR DESCRIPTION
This has been done in set_xdp_tuple(). Before this change, we have:

    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                vlan_gro_receive :0->:0()
    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                inet_gro_receive :0->:0()
    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                skb_defer_rx_timestamp :0->:0()
    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                get_rps_cpu :0->:0()
    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                __skb_get_hash :0->:0()
    0xffff8883ab72f800 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                enqueue_to_backlog :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                __netif_receive_skb :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                __netif_receive_skb_one_core :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                skb_vlan_untag :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    :0->:0()                                skb_pull_rcsum :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  84    10.0.32.12:0->10.0.32.7:0(icmp)         tc_run :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  84    10.0.32.12:0->10.0.32.7:0(icmp)         tcf_classify :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_ensure_writable :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_ensure_writable :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_do_redirect :0->:0()
    0xffff8883ab72f800 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         __bpf_redirect :0->:0()

With this change, we have:

    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         vlan_gro_receive :0->:0()
    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         inet_gro_receive :0->:0()
    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         skb_defer_rx_timestamp :0->:0()
    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         get_rps_cpu :0->:0()
    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         __skb_get_hash :0->:0()
    0xffff88824f1ac700 6   <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         enqueue_to_backlog :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         __netif_receive_skb :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         __netif_receive_skb_one_core :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         skb_vlan_untag :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x8100 1500  88    10.0.32.12:0->10.0.32.7:0(icmp)         skb_pull_rcsum :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  84    10.0.32.12:0->10.0.32.7:0(icmp)         tc_run :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  84    10.0.32.12:0->10.0.32.7:0(icmp)         tcf_classify :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_ensure_writable :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_ensure_writable :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         skb_do_redirect :0->:0()
    0xffff88824f1ac700 14  <empty>:0        4026531840 0             eth1:3      0x0800 1500  98    10.0.32.12:0->10.0.32.7:0(icmp)         __bpf_redirect :0->:0()