### PR TITLE
renovate: Fix syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,27 +13,27 @@
   "lockFileMaintenance": {
     "enabled": false
    },
+  "separateMajorMinor": false,
   "packageRules": [
     {
       "matchPackagePatterns": [
         "*"
       ],
       "groupName": "all dependencies"
+    },
+    {
+      "groupName": "all go dependencies main",
+      "groupSlug": "all-go-deps-main",
+      "matchFiles": [
+        "go.mod",
+        "go.sum"
+      ],
+      "postUpdateOptions": [
+        "gomodUpdateImportPaths"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ]
     }
-  ],
-  "separateMajorMinor": false,
-  {
-    "groupName": "all go dependencies main",
-    "groupSlug": "all-go-deps-main",
-    "matchFiles": [
-      "go.mod",
-      "go.sum"
-    ],
-    "postUpdateOptions": [
-      "gomodUpdateImportPaths"
-    ],
-    matchBaseBranches: [
-      "main"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Fixes: 6e999ef8a ("renovate: Try to fix go mod tidy issues")

Fix #554