### PR TITLE
Fix ARM build - BUILDPLATFORM arg is defined after use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.5 AS build
-ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG TARGETARCH
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.5 AS build
 
+ARG TARGETARCH    
 RUN gcc_pkg=$(if [ "${TARGETARCH}" = "arm64" ]; then echo "aarch64"; else echo "x86-64"; fi)  && \
     apt update && \
     apt install -y make git clang-15 llvm curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \


### PR DESCRIPTION
- Fix: BUILDPLATFORM was defined after FROM that refers to it.
- Removed unused TARGETPLATFORM