### PR TITLE
Bump clang to 19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.6 AS build
 ARG TARGETARCH    
 RUN gcc_pkg=$(if [ "${TARGETARCH}" = "arm64" ]; then echo "aarch64"; else echo "x86-64"; fi)  && \
     apt update && \
-    apt install -y make git clang-15 llvm curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \
-    ln -s /usr/bin/clang-15 /usr/bin/clang
+    apt install -y make git clang-19 llvm curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \
+    ln -s /usr/bin/clang-19 /usr/bin/clang
 
 WORKDIR /pwru
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ release:
 		--rm \
 		--workdir /pwru \
 		--volume `pwd`:/pwru docker.io/library/golang:1.24.1 \
-		sh -c "apt update && apt install -y make git clang-15 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
-			ln -s /usr/bin/clang-15 /usr/bin/clang && \
+		sh -c "apt update && apt install -y make git clang-19 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
+			ln -s /usr/bin/clang-19 /usr/bin/clang && \
 			git config --global --add safe.directory /pwru && \
 			make local-release"
 


### PR DESCRIPTION
clang-15 is no longer available on Debian Trixie, which is used to produce releases.