### PR TITLE
new: add logs for traced ebpf progs

### DIFF
--- a/internal/pwru/bpf_prog.go
+++ b/internal/pwru/bpf_prog.go
@@ -6,6 +6,7 @@ package pwru
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
@@ -27,6 +28,7 @@ func listBpfProgs(typ ebpf.ProgramType) ([]*ebpf.Program, error) {
 		}
 
 		if prog.Type() == typ {
+			log.Printf("Found bpf prog: %s\n", prog.String())
 			progs = append(progs, prog)
 		} else {
 			_ = prog.Close()
@@ -35,6 +37,10 @@ func listBpfProgs(typ ebpf.ProgramType) ([]*ebpf.Program, error) {
 
 	if !errors.Is(err, unix.ENOENT) { // Surely err != nil
 		return nil, err
+	}
+
+	if len(progs) == 0 {
+		log.Printf("No bpf progs found with type '%s'\n", typ.String())
 	}
 
 	return progs, nil


### PR DESCRIPTION
The idea behind this commit is to show the user which eBPF programs are found. 
I found it useful while testing the tool. If you don't see an event associated with a specific bpf program, there is always the doubt that the program is not found at all. Now this log should clarify the situation.

Example output:

```bash
sudo ./pwru 'src host 10.10.0.11' --filter-trace-tc 
```

```
2025/09/24 17:40:14 Attaching tc-bpf progs...
2025/09/24 17:40:14 Found bpf prog: SchedCLS(tcx_test)#17 
2025/09/24 17:40:15 Listening for events..
```

> [!NOTE]
> The output string is in the following format: `progType(progName)#fd`


Example output:

```bash
sudo ./pwru 'src host 10.10.0.11' --filter-trace-xdp
```

```
2025/09/24 17:50:04 Attaching xdp progs...
2025/09/24 17:50:04 No bpf progs found with type 'XDP'
2025/09/24 17:50:04 Attaching kprobes (via kprobe-multi)...
```