### PR TITLE
libpcap: build without DPDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ pwru: libpcap/libpcap.a
 ## Build libpcap for static linking
 libpcap/libpcap.a:
 	cd libpcap && \
-		CC=$(LIBPCAP_CC) ./configure --disable-protochain --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --host=$(LIBPCAP_ARCH) && \
+		CC=$(LIBPCAP_CC) ./configure --disable-protochain --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --without-dpdk --host=$(LIBPCAP_ARCH) && \
 		make
 
 ## Build the GO binary within a Docker container


### PR DESCRIPTION
The vendored libpcap builds with DPDK support if it finds it in the build machine. This fails build if the system DPDK version is too new (24.11.2 on my machine), and isn't desireable nevertheless.