### PR TITLE
renovate: update release Go image

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -3,7 +3,7 @@ name: Validate Renovate configuration
 on:
   pull_request:
     paths:
-      - 'renovate.json'
+      - 'renovate.json5'
 
 jobs:
   validate:
@@ -19,5 +19,5 @@ jobs:
           # renovate: datasource=docker
           export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:40.60.0@sha256:3af0fc62061baec7ed70cf482f81265462259470edfbe6ba714d568228eef70e
           docker run --rm --entrypoint "renovate-config-validator" \
-            -v "${{ github.workspace }}/renovate.json":"/renovate.json" \
-            ${RENOVATE_IMAGE} "/renovate.json"
+            -v "${{ github.workspace }}/renovate.json5":"/renovate.json5" \
+            ${RENOVATE_IMAGE} "/renovate.json5"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ ARCHS ?= amd64 arm64
 TEST_TIMEOUT ?= 5s
 .DEFAULT_GOAL := pwru
 
+# renovate: datasource=docker depName=golang
+GO_IMAGE_VERSION = 1.25.1
+GO_IMAGE_SHA = sha256:ab1f5c47de0f2693ed97c46a646bde2e4f380e40c173454d00352940a379af60
+
 ## Build the GO binary
 pwru: libpcap/libpcap.a
 	TARGET_GOARCH=$(TARGET_GOARCH) $(GO_GENERATE)
@@ -34,7 +38,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /pwru \
-		--volume `pwd`:/pwru docker.io/library/golang:1.24.1 \
+		--volume `pwd`:/pwru docker.io/library/golang:$(GO_IMAGE_VERSION)@$(GO_IMAGE_SHA) \
 		sh -c "apt update && apt install -y make git clang-19 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross && \
 			ln -s /usr/bin/clang-19 /usr/bin/clang && \
 			git config --global --add safe.directory /pwru && \

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,5 +37,20 @@
       ],
       "matchBaseBranches": ["main"]
     }
-  ]
+  ],
+  customManagers: [
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^Makefile$',
+      ],
+
+      // This regex manages version strings in the Makefile,
+      // similar to the examples shown here:
+      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
Let renovate update the Go image version used for building release binaries. Also update to Go 1.25.1 while at it.