### PR TITLE
Modernize Go code

### DIFF
--- a/internal/byteorder/byteorder_bigendian.go
+++ b/internal/byteorder/byteorder_bigendian.go
@@ -2,7 +2,6 @@
 // Copyright 2021 Authors of Cilium
 
 //go:build armbe || arm64be || mips || mips64 || ppc64
-// +build armbe arm64be mips mips64 ppc64
 
 package byteorder
 

--- a/internal/byteorder/byteorder_littleendian.go
+++ b/internal/byteorder/byteorder_littleendian.go
@@ -2,7 +2,6 @@
 // Copyright 2021-2022 Authors of Cilium
 
 //go:build 386 || amd64 || arm || arm64 || loong64 || mips64le || ppc64le || riscv64 || wasm
-// +build 386 amd64 arm arm64 loong64 mips64le ppc64le riscv64 wasm
 
 package byteorder
 

--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -58,24 +58,24 @@ type output struct {
 
 // outputStructured is a struct to hold the data for the json output
 type jsonPrinter struct {
-	Skb         string      `json:"skb,omitempty"`
-	Shinfo      string      `json:"skb_shared_info,omitempty"`
-	Cpu         uint32      `json:"cpu,omitempty"`
-	Process     string      `json:"process,omitempty"`
-	Func        string      `json:"func,omitempty"`
-	CallerFunc  string      `json:"caller_func,omitempty"`
-	Time        interface{} `json:"time,omitempty"`
-	Netns       uint32      `json:"netns,omitempty"`
-	Mark        uint32      `json:"mark,omitempty"`
-	Iface       string      `json:"iface,omitempty"`
-	Proto       uint16      `json:"proto,omitempty"`
-	Mtu         uint32      `json:"mtu,omitempty"`
-	Len         uint32      `json:"len,omitempty"`
-	Cb          [5]uint32   `json:"cb,omitempty"`
-	Tuple       *jsonTuple  `json:"tuple,omitempty"`
-	TunnelTuple *jsonTuple  `json:"tunnel_tuple,omitempty"`
-	Stack       interface{} `json:"stack,omitempty"`
-	SkbMetadata interface{} `json:"skb_metadata,omitempty"`
+	Skb         string     `json:"skb,omitempty"`
+	Shinfo      string     `json:"skb_shared_info,omitempty"`
+	Cpu         uint32     `json:"cpu,omitempty"`
+	Process     string     `json:"process,omitempty"`
+	Func        string     `json:"func,omitempty"`
+	CallerFunc  string     `json:"caller_func,omitempty"`
+	Time        any        `json:"time,omitempty"`
+	Netns       uint32     `json:"netns,omitempty"`
+	Mark        uint32     `json:"mark,omitempty"`
+	Iface       string     `json:"iface,omitempty"`
+	Proto       uint16     `json:"proto,omitempty"`
+	Mtu         uint32     `json:"mtu,omitempty"`
+	Len         uint32     `json:"len,omitempty"`
+	Cb          [5]uint32  `json:"cb,omitempty"`
+	Tuple       *jsonTuple `json:"tuple,omitempty"`
+	TunnelTuple *jsonTuple `json:"tunnel_tuple,omitempty"`
+	Stack       any        `json:"stack,omitempty"`
+	SkbMetadata any        `json:"skb_metadata,omitempty"`
 }
 
 type jsonTuple struct {

--- a/internal/pwru/output_bench_test.go
+++ b/internal/pwru/output_bench_test.go
@@ -73,8 +73,7 @@ func BenchmarkOutputPrint(b *testing.B) {
 		},
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		output.Print(event)
 	}
 }

--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -45,7 +45,6 @@ func (t *tracing) detach() {
 	var errg errgroup.Group
 
 	for _, l := range t.links {
-		l := l
 		errg.Go(func() error {
 			_ = l.Close()
 			return nil
@@ -134,7 +133,6 @@ func (t *tracing) trace(coll *ebpf.Collection, spec *ebpf.CollectionSpec,
 	var errg errgroup.Group
 
 	for _, prog := range progs {
-		prog := prog
 		errg.Go(func() error {
 			return t.traceProg(spec, opts, prog, tracingName)
 		})


### PR DESCRIPTION
Run `modernize -fix ./...` to modernize Go code:

- Remove old-style `+build` tags
- Replace `interface{}` by `any`
- Remove unnecessary loop variable copies
- Use `testing.B.Loop` in benchmark