### PR TITLE
go.mod, tools: use Go 1.24 tool dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	rsc.io/c2go v0.0.0-20170620140410-520c22818a08 // indirect
 )
+
+tool github.com/cilium/ebpf/cmd/bpf2go

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Authors of Cilium
-
-//go:build tools
-// +build tools
-
-package tools
-
-import _ "github.com/cilium/ebpf/cmd/bpf2go"


### PR DESCRIPTION
Use the tool go.mod directive introduced in Go 1.24 [^1] to specify the ebpf2go tool that is needed during build. This allows to drop the tools/tools.go which was used so far to pull in this dependency.

[^1]: https://go.dev/doc/modules/managing-dependencies#tools