### PR TITLE
Add script to run pwru on k8s node to own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ kubectl wait pod pwru --for condition=Ready --timeout=90s
 kubectl logs -f pwru
 ```
 
+Also see [contrib/scripts/pwru-on-k8s-node](contrib/scripts/pwru-on-k8s-node) for a reusable version of this script.
+
 ## Distro packages
 
 `pwru` is available in some distro packages. [GH#89](https://github.com/cilium/pwru/issues/89) tracks any packaging work and progress.

--- a/contrib/scripts/pwru-on-k8s-node
+++ b/contrib/scripts/pwru-on-k8s-node
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 1 ] ; then
+  echo "usage: $0 <node> [pwru args...]"
+  exit 1
+fi
+
+NODE=$1
+shift
+PWRU_ARGS="$@"
+
+trap "kubectl delete --wait=false pod pwru" EXIT
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pwru
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: ${NODE}
+  containers:
+  - image: docker.io/cilium/pwru:latest
+    name: pwru
+    volumeMounts:
+    - mountPath: /sys/kernel/debug
+      name: sys-kernel-debug
+    securityContext:
+      privileged: true
+    command: ["/bin/sh"]
+    args: ["-c", "pwru ${PWRU_ARGS}"]
+  volumes:
+  - name: sys-kernel-debug
+    hostPath:
+      path: /sys/kernel/debug
+      type: DirectoryOrCreate
+  hostNetwork: true
+  hostPID: true
+EOF
+
+kubectl wait pod pwru --for condition=Ready --timeout=90s
+kubectl logs -f pwru


### PR DESCRIPTION
Adjust the example script from the README describing how to run pwru on a given k8s node to its own script file and allow it to take node name and pwru commandline arguments. This allows more easily reusing the script.