### PR TITLE
Replace per-CPU counter maps with global atomic counters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.2 AS build
 
-ARG TARGETARCH    
-RUN gcc_pkg=$(if [ "${TARGETARCH}" = "arm64" ]; then echo "aarch64"; else echo "x86-64"; fi)  && \
+ARG TARGETARCH
+RUN gcc_pkg=$(if [ "${TARGETARCH}" = "arm64" ]; then echo "aarch64"; else echo "x86-64"; fi) && \
     apt update && \
-    apt install -y make git clang-19 llvm curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \
-    ln -s /usr/bin/clang-19 /usr/bin/clang
+    apt install -y make git wget lsb-release gnupg curl gcc flex bison gcc-${gcc_pkg}* libc6-dev-${TARGETARCH}-cross && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 && rm llvm.sh && \
+    ln -sf /usr/bin/clang-20 /usr/bin/clang
 
 WORKDIR /pwru
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ release:
 		--rm \
 		--workdir /pwru \
 		--volume `pwd`:/pwru docker.io/library/golang:$(GO_IMAGE_VERSION)@$(GO_IMAGE_SHA) \
-		sh -c "apt update && apt install -y make git clang-19 llvm curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross gcc-riscv64* libc6-dev-riscv64-cross && \
-			ln -s /usr/bin/clang-19 /usr/bin/clang && \
+		sh -c "apt update && apt install -y make git wget lsb-release gnupg curl gcc flex bison gcc-aarch64* libc6-dev-arm64-cross gcc-riscv64* libc6-dev-riscv64-cross && \
+			wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 && rm llvm.sh && \
+			ln -sf /usr/bin/clang-20 /usr/bin/clang && \
 			git config --global --add safe.directory /pwru && \
 			make local-release"
 

--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -31,6 +31,10 @@
 const static bool TRUE = true;
 const static u32 ZERO = 0;
 
+u64 print_skb_id = 0;
+u64 print_shinfo_id = 0;
+u64 print_bpfmap_id = 0;
+
 const volatile u32 ENDBR_INSN_SIZE = 0;
 
 enum {
@@ -209,35 +213,17 @@ struct print_bpfmap_value {
 	u8 value[256];
 } __attribute__((packed));
 struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, u32);
-} print_skb_id_map SEC(".maps");
-struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 256);
 	__type(key, u64);
 	__type(value, struct print_skb_value);
 } print_skb_map SEC(".maps");
 struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, u32);
-} print_shinfo_id_map SEC(".maps");
-struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 256);
 	__type(key, u64);
 	__type(value, struct print_shinfo_value);
 } print_shinfo_map SEC(".maps");
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, u32);
-} print_bpfmap_id_map SEC(".maps");
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
@@ -455,14 +441,6 @@ set_tunnel(struct sk_buff *skb, struct tuple *tpl, struct tuple *tunnel_tpl) {
 	__set_tuple(tunnel_tpl, skb_head, tunnel_l3_off, is_ipv4);
 }
 
-static __always_inline u64
-sync_fetch_and_add(void *id_map) {
-	u32 *id = bpf_map_lookup_elem(id_map, &ZERO);
-	if (id)
-		return ((*id)++) | ((u64)(bpf_get_smp_processor_id() + 1) << 32);
-	return 0;
-}
-
 static __always_inline void
 set_skb_btf(struct sk_buff *skb, u64 *event_id) {
 	struct btf_ptr p = {};
@@ -474,7 +452,7 @@ set_skb_btf(struct sk_buff *skb, u64 *event_id) {
 
 	p.type_id = cfg->skb_btf_id;
 	p.ptr = skb;
-	*event_id = sync_fetch_and_add(&print_skb_id_map);
+	*event_id = __sync_fetch_and_add(&print_skb_id, 1);
 
 	v->len = bpf_snprintf_btf(v->str, PRINT_SKB_STR_SIZE, &p, sizeof(p), 0);
 	if (v->len < 0) {
@@ -509,7 +487,7 @@ set_shinfo_btf(struct sk_buff *skb, u64 *event_id) {
 	p.type_id = cfg->shinfo_btf_id;
 	p.ptr = shinfo;
 
-	*event_id = sync_fetch_and_add(&print_shinfo_id_map);
+	*event_id = __sync_fetch_and_add(&print_shinfo_id, 1);
 
 	v->len = bpf_snprintf_btf(v->str, PRINT_SHINFO_STR_SIZE, &p, sizeof(p), 0);
 	if (v->len < 0) {
@@ -1070,7 +1048,7 @@ set_common_bpfmap_info(struct pt_regs *ctx, u64 *event_id,
 		       struct print_bpfmap_value *bpfmap) {
 	struct bpf_map *map = (struct bpf_map *)PT_REGS_PARM1(ctx);
 
-	*event_id = sync_fetch_and_add(&print_bpfmap_id_map);
+	*event_id = __sync_fetch_and_add(&print_bpfmap_id, 1);
 	BPF_CORE_READ_INTO(&bpfmap->id, map, id);
 	BPF_CORE_READ_STR_INTO(&bpfmap->name, map, name);
 	BPF_CORE_READ_INTO(&bpfmap->key_size, map, key_size);

--- a/build.go
+++ b/build.go
@@ -2,6 +2,6 @@
 // Copyright (C) 2021 Authors of Cilium */
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip KProbePWRU ./bpf/kprobe_pwru.c -- -I./bpf/headers -Wno-address-of-packed-member -mcpu=v3
 
 package main

--- a/test-app/main.go
+++ b/test-app/main.go
@@ -2,7 +2,7 @@
 /* Copyright Authors of Cilium */
 
 //go:generate sh -c "echo Generating for $TARGET_GOARCH"
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip bpf bpf.c -- -I../bpf/headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET_GOARCH -cc clang -no-strip bpf bpf.c -- -I../bpf/headers -mcpu=v3
 package main
 
 import (


### PR DESCRIPTION
PR #412 introduced a sync_fetch_and_add() helper and 3 per-CPU array counter maps as a workaround for -mcpu=v1 not supporting atomic fetch instructions. Since we can enable -mcpu=v3 (BPF ISA v3 has been available since kernel 5.1, and pwru requires >= 5.3), we can revert to the simpler approach:  __sync_fetch_and_add() on global u64 variables.
This removes the custom helper and the per-CPU maps entirely. 

Note that verifying the -mcpu=v3 requirement at compile time is currently not possible with our toolchain. clang 19 always emits atomic_fetch_add regardless of -mcpu due to llvm/llvm-project#101428, which was reverted in clang 20. With clang 20, building with -mcpu=v1 correctly produces the "Invalid usage of the XADD return value" error.