### PR TITLE
Free cached BTF and verifier log to reduce memory use

### DIFF
--- a/internal/pwru/tracing.go
+++ b/internal/pwru/tracing.go
@@ -90,6 +90,10 @@ func (t *tracing) traceProg(spec *ebpf.CollectionSpec,
 	}
 	defer coll.Close()
 
+	for _, prog := range coll.Programs {
+		prog.VerifierLog = ""
+	}
+
 	tracing, err := link.AttachTracing(link.TracingOptions{
 		Program: coll.Programs[tracingName],
 	})

--- a/main.go
+++ b/main.go
@@ -287,6 +287,10 @@ func run(flags pwru.Flags) error {
 	}
 	defer coll.Close()
 
+	for _, prog := range coll.Programs {
+		prog.VerifierLog = ""
+	}
+
 	traceTc := false
 	if flags.FilterTraceTc {
 		t, err := pwru.TraceTC(coll, bpfSpecFentryTc, &opts)
@@ -339,6 +343,8 @@ func run(flags pwru.Flags) error {
 		}
 		defer k.DetachKprobes()
 	}
+
+	btf.FlushKernelSpec()
 
 	slog.Info("Listening for events..")
 


### PR DESCRIPTION
pprof/heap shows:

```
(pprof) top
Showing nodes accounting for 12116.15kB, 100% of 12116.15kB total Showing top 10 nodes out of 32
      flat  flat%   sum%        cum   cum%
    5180kB 42.75% 42.75%     5180kB 42.75%  golang.org/x/sys/unix.ByteSliceToString
    3078kB 25.40% 68.16%     3078kB 25.40%  runtime.allocm
 1408.02kB 11.62% 79.78%  2321.85kB 19.16%  github.com/cilium/ebpf/btf.newDecoder
  913.83kB  7.54% 87.32%   913.83kB  7.54%  github.com/cilium/ebpf/btf.newFuzzyStringIndex
  512.22kB  4.23% 91.55%   512.22kB  4.23%  runtime.malg
  512.05kB  4.23% 95.77%   512.05kB  4.23%  github.com/cilium/ebpf/features.init
  512.03kB  4.23%   100%  5692.03kB 46.98%  github.com/cilium/ebpf.newProgramWithOptions
         0     0%   100%  5692.03kB 46.98%  github.com/cilium/ebpf.(*collectionLoader).loadProgram
         0     0%   100%  5692.03kB 46.98%  github.com/cilium/ebpf.NewCollectionWithOptions
         0     0%   100%  2321.85kB 19.16%  github.com/cilium/ebpf/btf.LoadKernelSpec
```

The String* and cilium/ebpf/* related heap objects are mainly for bpf verifier log and cached BTF, I believe we don't need them after loading and attaching.

This patch frees the references to verifier log and cached BTF, manages to cut 33% memory from 30M to 20M.

The new pprof/heap top has no big stale cilium/ebpf/* heap objects:

```
(pprof) top
Showing nodes accounting for 6667.79kB, 100% of 6667.79kB total Showing top 10 nodes out of 19
      flat  flat%   sum%        cum   cum%
 5643.01kB 84.63% 84.63%  5643.01kB 84.63%  runtime.allocm
  512.56kB  7.69% 92.32%   512.56kB  7.69%  github.com/cilium/ebpf/features.init
  512.22kB  7.68%   100%   512.22kB  7.68%  runtime.malg
         0     0%   100%   512.56kB  7.69%  runtime.doInit (inline)
         0     0%   100%   512.56kB  7.69%  runtime.doInit1
         0     0%   100%   512.56kB  7.69%  runtime.main
         0     0%   100%     2052kB 30.77%  runtime.mcall
         0     0%   100%     3591kB 53.86%  runtime.mstart
         0     0%   100%     3591kB 53.86%  runtime.mstart0
         0     0%   100%     3591kB 53.86%  runtime.mstart1
```

Signed-off: gray <greyschwinger@gmail.com>