### PR TITLE
fix: honor output-tunnel in JSON output

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -243,7 +243,7 @@ func (o *output) PrintJson(event *Event) error {
 		d.Tuple = t
 	}
 
-	if o.flags.OutputTuple {
+	if o.flags.OutputTunnel {
 		t := &jsonTuple{}
 		t.Saddr = addrToStr(event.TunnelTuple.L3Proto, event.TunnelTuple.Saddr)
 		t.Daddr = addrToStr(event.TunnelTuple.L3Proto, event.TunnelTuple.Daddr)

--- a/internal/pwru/output_test.go
+++ b/internal/pwru/output_test.go
@@ -4,7 +4,10 @@
 package pwru
 
 import (
+	"bytes"
+	"encoding/json"
 	"regexp"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -21,5 +24,71 @@ func TestGetAbsoluteTs(t *testing.T) {
 
 	if _, err := time.Parse(absoluteTS, ts); err != nil {
 		t.Fatalf("failed to parse timestamp %q: %v", ts, err)
+	}
+}
+
+func TestPrintJSONTunnelTupleOn(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	out := newBenchmarkOutput(outBuf)
+	out.flags.OutputTuple = false
+	out.flags.OutputTunnel = true
+
+	event := newBenchmarkEvent()
+	event.TunnelTuple = Tuple{
+		Saddr:   [16]byte{10, 0, 0, 1},
+		Daddr:   [16]byte{10, 0, 0, 2},
+		Sport:   4789,
+		Dport:   8472,
+		L3Proto: syscall.ETH_P_IP,
+		L4Proto: syscall.IPPROTO_UDP,
+	}
+
+	if err := out.PrintJson(event); err != nil {
+		t.Fatalf("PrintJson() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(outBuf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal json output: %v", err)
+	}
+
+	if _, ok := got["tuple"]; ok {
+		t.Fatalf("unexpected tuple field in json output: %s", outBuf.String())
+	}
+	if _, ok := got["tunnel_tuple"]; !ok {
+		t.Fatalf("missing tunnel_tuple field in json output: %s", outBuf.String())
+	}
+}
+
+func TestPrintJSONTunnelTupleOff(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	out := newBenchmarkOutput(outBuf)
+	out.flags.OutputTuple = true
+	out.flags.OutputTunnel = false
+
+	event := newBenchmarkEvent()
+	event.TunnelTuple = Tuple{
+		Saddr:   [16]byte{10, 0, 0, 1},
+		Daddr:   [16]byte{10, 0, 0, 2},
+		Sport:   4789,
+		Dport:   8472,
+		L3Proto: syscall.ETH_P_IP,
+		L4Proto: syscall.IPPROTO_UDP,
+	}
+
+	if err := out.PrintJson(event); err != nil {
+		t.Fatalf("PrintJson() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(outBuf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal json output: %v", err)
+	}
+
+	if _, ok := got["tuple"]; !ok {
+		t.Fatalf("missing tuple field in json output: %s", outBuf.String())
+	}
+	if _, ok := got["tunnel_tuple"]; ok {
+		t.Fatalf("unexpected tunnel_tuple field in json output: %s", outBuf.String())
 	}
 }


### PR DESCRIPTION
`PrintJson()` checked `OutputTuple` for `tunnel_tuple`, not `OutputTunnel`.

So 2 cases get kinda weird:
- `pwru --output-json --output-tunnel --output-tuple=false` drops `tunnel_tuple`
- `pwru --output-json --output-tuple --output-tunnel=false` still prints `tunnel_tuple`

This switches the guard to `OutputTunnel` and adds regression tests. Pretty small fix, but it keeps JSON output lined up with the flags.

Repro:
1. Run `go test ./internal/pwru -run "TestPrintJSON|TestGetAbsoluteTs" -v`
2. Before the fix, the 2 `TestPrintJSON...` cases fail
3. With this patch, they pass
