### PR TITLE
fix: preserve shared info in JSON output

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -289,13 +289,16 @@ func (o *output) PrintJson(event *Event) error {
 		d.Stack = getStackData(event, o)
 	}
 
+	var skbData, shinfoData string
 	if o.flags.OutputSkb {
-		d.SkbMetadata = getSkbData(event, o)
+		skbData = getSkbData(event, o)
 	}
 
 	if o.flags.OutputShinfo {
-		d.SkbMetadata = getShinfoData(event, o)
+		shinfoData = getShinfoData(event, o)
 	}
+
+	setJSONPacketData(d, o.flags, skbData, shinfoData)
 
 	// Create new encoder to write the json to stdout or file depending on the flags
 	encoder := json.NewEncoder(o.writer)
@@ -306,6 +309,15 @@ func (o *output) PrintJson(event *Event) error {
 		return fmt.Errorf("error encoding JSON: %s", err)
 	}
 	return nil
+}
+
+func setJSONPacketData(d *jsonPrinter, flags *Flags, skbData, shinfoData string) {
+	if flags.OutputSkb {
+		d.SkbMetadata = skbData
+	}
+	if flags.OutputShinfo {
+		d.Shinfo = shinfoData
+	}
 }
 
 func getAbsoluteTs() string {

--- a/internal/pwru/output_test.go
+++ b/internal/pwru/output_test.go
@@ -102,3 +102,17 @@ func TestPrintJSONTupleFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSetJSONPacketData(t *testing.T) {
+	d := &jsonPrinter{}
+	flags := &Flags{OutputSkb: true, OutputShinfo: true}
+
+	setJSONPacketData(d, flags, "skb", "shared info")
+
+	if d.SkbMetadata != "skb" {
+		t.Fatalf("skb_metadata = %q, want %q", d.SkbMetadata, "skb")
+	}
+	if d.Shinfo != "shared info" {
+		t.Fatalf("skb_shared_info = %q, want %q", d.Shinfo, "shared info")
+	}
+}


### PR DESCRIPTION
it fixes overwrite in JSON output

When `--output-skb` and `--output-skb-shared-info` are both enabled, both payloads were written to `skb_metadata`. The second write wiped the first, and `skb_shared_info` never showed up

Keep skb data in `skb_metadata` and write shared info to the existing `skb_shared_info` field. Both fields show up now

Repro on the unfixed build:

```sh
sudo ./pwru --filter-func=ip_rcv --output-json \
  --output-skb --output-skb-shared-info --output-limit-lines=1
```

Wait for one packet, the old output has `skb_metadata` containing the shared-info dump, but no `skb_shared_info` field

Tests: `make test`