### PR TITLE
gh/workflows: Publish :latest tag too

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -38,7 +38,11 @@ jobs:
             tag=${{ github.sha }}
           fi
           echo tag=$tag >> $GITHUB_OUTPUT
-          echo image_tags=${{ github.repository_owner }}/pwru:$tag >> $GITHUB_OUTPUT
+          image_tags=${{ github.repository_owner }}/pwru:$tag
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            image_tags="$image_tags,${{ github.repository_owner }}/pwru:latest"
+          fi
+          echo image_tags=$image_tags >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Just noticed, that cilium/pwru:latest was updated only a year ago \[1\]. This is because we forgot to enable publishing of the latest in image.yaml.

\[1\]: https://hub.docker.com/r/cilium/pwru/tags