### PR TITLE
fix: preserve relative timestamps in JSON output

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -227,8 +227,6 @@ func (o *output) PrintJson(event *Event) error {
 		d.CallerFunc = o.addr2name.findNearestSym(event.CallerAddr)
 	}
 
-	o.lastSeenSkb[event.SkbAddr] = event.Timestamp
-
 	// add the timestamp to the struct if it is not set to none
 	if o.flags.OutputTS != "none" {
 		switch o.flags.OutputTS {
@@ -240,6 +238,7 @@ func (o *output) PrintJson(event *Event) error {
 			d.Time = event.Timestamp
 		}
 	}
+	o.lastSeenSkb[event.SkbAddr] = event.Timestamp
 
 	if o.flags.OutputMeta {
 		d.Netns = event.Meta.Netns

--- a/internal/pwru/output_test.go
+++ b/internal/pwru/output_test.go
@@ -116,3 +116,30 @@ func TestSetJSONPacketData(t *testing.T) {
 		t.Fatalf("skb_shared_info = %q, want %q", d.Shinfo, "shared info")
 	}
 }
+
+func TestPrintJSONRelativeTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	out := newBenchmarkOutput(&buf)
+	out.flags.OutputTS = "relative"
+
+	first := newBenchmarkEvent()
+	first.Timestamp = 100
+	if err := out.PrintJson(first); err != nil {
+		t.Fatal(err)
+	}
+
+	second := newBenchmarkEvent()
+	second.Timestamp = 250
+	if err := out.PrintJson(second); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte{'\n'})
+	var got map[string]any
+	if err := json.Unmarshal(lines[1], &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["time"] != float64(150) {
+		t.Fatalf("relative time = %v, want 150", got["time"])
+	}
+}


### PR DESCRIPTION
Fix relative JSON timestamps for repeated skb events. 
The cache now updates after calculating `time`, so JSON matches text output

Repro:
`sudo pwru --output-json --timestamp=relative 'icmp and host 127.0.0.1'`
Run `ping -c1 127.0.0.1`. 
Before this, later events for one `skb` show `time: 0`; now they show the delta