### PR TITLE
fix: close namespace FDs while collecting interfaces

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -723,9 +723,11 @@ func getIfaces() (map[uint64]map[uint32]string, error) {
 		}
 		var stat unix.Stat_t
 		if err0 := unix.Fstat(int(fd.Fd()), &stat); err0 != nil {
+			_ = fd.Close()
 			err = errors.Join(err, err0)
 			continue
 		}
+		_ = fd.Close()
 		inode := stat.Ino
 
 		if _, exists := ifaceCache[inode]; exists {
@@ -750,11 +752,13 @@ func getIfacesInNetNs(path string) (map[uint32]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer current.Close()
 
 	remote, err := netns.GetFromPath(path)
 	if err != nil {
 		return nil, err
 	}
+	defer remote.Close()
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/internal/pwru/output_fd_repro_test.go
+++ b/internal/pwru/output_fd_repro_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright Authors of Cilium */
+
+package pwru
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetIfacesDoesNotLeakNamespaceFDs(t *testing.T) {
+	before, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = getIfaces()
+
+	after, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("getIfaces left %d namespace descriptors open", len(after)-len(before))
+	}
+}


### PR DESCRIPTION
`getIfaces` kept namespace FDs open while building the default metadata cache. They pile up fast on busy nodes

Close them after the inode lookup and close the temporary namespace handles. No behavior change besides releasing them

Repro: apply this test to the parent commit, then run `go test ./internal/pwru -run TestGetIfacesDoesNotLeakNamespaceFDs -count=1`
It fails with leaked FDs. This PR passes