### PR TITLE
fix: filter packets with a zero mark

### DIFF
--- a/bpf/kprobe_pwru.c
+++ b/bpf/kprobe_pwru.c
@@ -272,7 +272,7 @@ filter_meta(struct sk_buff *skb) {
 	if (cfg->netns && get_netns(skb) != cfg->netns) {
 			return false;
 	}
-	if (cfg->mark && cfg->mask && (BPF_CORE_READ(skb, mark) & cfg->mask) != cfg->mark) {
+	if (cfg->mask && (BPF_CORE_READ(skb, mark) & cfg->mask) != cfg->mark) {
 		return false;
 	}
 	if (cfg->ifindex != 0 && BPF_CORE_READ(skb, dev, ifindex) != cfg->ifindex) {

--- a/internal/pwru/config.go
+++ b/internal/pwru/config.go
@@ -57,7 +57,7 @@ type FilterCfg struct {
 
 func GetConfig(flags *Flags) (cfg FilterCfg, err error) {
 	cfg = FilterCfg{
-		FilterMark:     flags.FilterMark,
+		FilterMark:     flags.FilterMark & flags.FilterMarkMask,
 		FilterMarkMask: flags.FilterMarkMask,
 	}
 	cfg.FilterFlags |= IsSetMask

--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -90,7 +90,7 @@ func (f *Flags) SetFlags() {
 	flag.StringVar(&f.FilterFunc, "filter-func", "", "filter kernel functions to be probed by name (exact match, supports RE2 regular expression)")
 	flag.StringSliceVar(&f.FilterNonSkbFuncs, "filter-non-skb-funcs", nil, "filter non-skb kernel functions to be probed (--filter-track-skb-by-stackid will be enabled)")
 	flag.StringVar(&f.FilterNetns, "filter-netns", "", "filter netns (\"/proc/<pid>/ns/net\", \"inode:<inode>\")")
-	flag.Var(newMarkFlagValue(&f.FilterMark, &f.FilterMarkMask), "filter-mark", "filter skb mark (format: mark[/mask], e.g., 0xa00/0xf00)")
+	flag.Var(newMarkFlagValue(&f.FilterMark, &f.FilterMarkMask), "filter-mark", "filter skb mark (format: mark[/mask], e.g., 0xa00/0xf00; default: 0/0; exact match if mask is omitted)")
 	flag.BoolVar(&f.FilterTrackSkb, "filter-track-skb", false, "trace a packet even if it does not match given filters (e.g., after NAT or tunnel decapsulation)")
 	flag.BoolVar(&f.FilterTrackSkbByStackid, "filter-track-skb-by-stackid", false, "trace a packet even after it is kfreed (e.g., traffic going through bridge)")
 	flag.BoolVar(&f.FilterTraceTc, "filter-trace-tc", false, "trace TC bpf progs")
@@ -237,9 +237,6 @@ func newMarkFlagValue(mark, mask *uint32) *markFlagValue {
 }
 
 func (f *markFlagValue) String() string {
-	if *f.mask == 0 {
-		return fmt.Sprintf("0x%x", *f.mark)
-	}
 	return fmt.Sprintf("0x%x/0x%x", *f.mark, *f.mask)
 }
 

--- a/internal/pwru/types_test.go
+++ b/internal/pwru/types_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright Authors of Cilium */
+
+package pwru
+
+import "testing"
+
+func TestMarkFlagValue(t *testing.T) {
+	var mark, mask uint32
+	f := newMarkFlagValue(&mark, &mask)
+
+	if got, want := f.String(), "0x0/0x0"; got != want {
+		t.Fatalf("default String() = %q, want %q", got, want)
+	}
+
+	if err := f.Set("0xa5"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if mark != 0xa5 || mask != 0xffffffff {
+		t.Fatalf("Set() = mark %#x, mask %#x; want mark %#x, mask %#x", mark, mask, uint32(0xa5), uint32(0xffffffff))
+	}
+
+	if err := f.Set("0xaf/0x0f"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if mark != 0xaf || mask != 0x0f {
+		t.Fatalf("Set() = mark %#x, mask %#x; want mark %#x, mask %#x", mark, mask, uint32(0xaf), uint32(0x0f))
+	}
+}


### PR DESCRIPTION
`--filter-mark=0` skipped its BPF check, so a packet marked `42` still showed up. 
fix: use the mask as the filter guard.

Repro:
```sh
sudo pwru --filter-func=ip_output --filter-mark=0 --output-json --output-limit-lines=1 "udp and port 54331"
# send a UDP packet to port 54331 with SO_MARK=42
```

Before, output contains `"mark":42`. After this change, it prints no event. 
and zero marks now work too