### PR TITLE
fix: prevent output-bpfmap panics for oversized fields

### DIFF
--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -289,8 +289,8 @@ type printBpfmapValue struct {
 }
 
 func (i *printBpfmapValue) String() string {
-	key := fmt.Sprintf("%s", hex.Dump(i.Key[:i.KeySize]))
-	value := fmt.Sprintf("%s", hex.Dump(i.Value[:i.ValueSize]))
+	key := fmt.Sprintf("%s", hex.Dump(i.Key[:min(i.KeySize, uint32(len(i.Key)))]))
+	value := fmt.Sprintf("%s", hex.Dump(i.Value[:min(i.ValueSize, uint32(len(i.Value)))]))
 	return fmt.Sprintf("map_id: %d\nmap_name: %s\nkey(%d):\n%svalue(%d):\n%s",
 		i.Id, i.Name, i.KeySize, key, i.ValueSize, value)
 }

--- a/internal/pwru/types_test.go
+++ b/internal/pwru/types_test.go
@@ -3,7 +3,13 @@
 
 package pwru
 
-import "testing"
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
 
 func TestMarkFlagValue(t *testing.T) {
 	var mark, mask uint32
@@ -25,5 +31,38 @@ func TestMarkFlagValue(t *testing.T) {
 	}
 	if mark != 0xaf || mask != 0x0f {
 		t.Fatalf("Set() = mark %#x, mask %#x; want mark %#x, mask %#x", mark, mask, uint32(0xaf), uint32(0x0f))
+	}
+}
+
+func TestPrintBpfmapValueStringTruncatesOversizedFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    uint32
+		wantLen int
+	}{
+		{"zero", 0, 0},
+		{"maximum captured", 256, 256},
+		{"oversized", 257, 256},
+		{"maximum uint32", math.MaxUint32, 256},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := printBpfmapValue{KeySize: tt.size, ValueSize: tt.size}
+			for i := range v.Key {
+				v.Key[i] = byte(i)
+				v.Value[i] = byte(i)
+			}
+
+			got := v.String()
+			want := fmt.Sprintf(
+				"key(%d):\n%svalue(%d):\n%s",
+				tt.size, hex.Dump(v.Key[:tt.wantLen]),
+				tt.size, hex.Dump(v.Value[:tt.wantLen]),
+			)
+			if !strings.Contains(got, want) {
+				t.Fatalf("String() missing expected dump:\n%s", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #709

`--output-bpfmap` panics when a traced map key or value is larger than 256 bytes. Keep the real size in output, dump the captured 256-byte prefix

Repro: run pwru with `--output-bpfmap` while a TC BPF program updates a map with a 257-byte key or value. Before this it panics with `slice bounds out of range [:257] with length 256`.