### PR TITLE
build: use clang for libpcap and CGO by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 VERSION=$(shell git describe --tags --always)
 LIBPCAP_ARCH ?= x86_64-unknown-linux-gnu
-# For compiling libpcap and CGO
-CC ?= gcc
+# For compiling libpcap and CGO (match BPF builds which already use clang)
+CC ?= clang
+LIBPCAP_CC ?= $(CC)
 ARCHS ?= amd64 arm64 riscv64
 
 TEST_TIMEOUT ?= 5s

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 VERSION=$(shell git describe --tags --always)
 LIBPCAP_ARCH ?= x86_64-unknown-linux-gnu
-# For compiling libpcap and CGO (match BPF builds which already use clang)
+# For compiling libpcap and CGO (match BPF builds which already use clang).
+# Cross builds pass CFLAGS/CGO_* --target=... via local-release.sh; gcc cross
+# packages remain required for target binutils/libc that clang links against.
 CC ?= clang
 LIBPCAP_CC ?= $(CC)
 ARCHS ?= amd64 arm64 riscv64

--- a/local-release.sh
+++ b/local-release.sh
@@ -13,12 +13,13 @@ for ARCH in ${ARCHS}; do
         CC=riscv64-linux-gnu-gcc
     else
         LIBPCAP_ARCH=x86_64-unknown-linux-gnu
-        CC=x86_64-linux-gnu-gcc
+        # Use clang for native amd64 libpcap/CGO (matches BPF compilation).
+        CC=clang
     fi
 
     make clean
     echo "Building release binary for ${OS}/${ARCH}..."
-    make pwru TARGET_GOARCH=${ARCH} LIBPCAP_ARCH=${LIBPCAP_ARCH} CC=${CC} 
+    make pwru TARGET_GOARCH=${ARCH} LIBPCAP_ARCH=${LIBPCAP_ARCH} CC=${CC} LIBPCAP_CC=${CC}
 
     test -d release/${OS}/${ARCH} || mkdir -p release/${OS}/${ARCH}
     tar -czf release/pwru-${OS}-${ARCH}.tar.gz pwru

--- a/local-release.sh
+++ b/local-release.sh
@@ -5,21 +5,27 @@ set -uex
 OS=linux
 
 for ARCH in ${ARCHS}; do
+    # Use clang for libpcap/CGO on every arch (same compiler as BPF builds).
+    # --target selects the triple; gcc-*-linux-gnu packages still provide the
+    # cross binutils/libc that clang drives when linking.
     if [ "$ARCH" = "arm64" ]; then
         LIBPCAP_ARCH=aarch64-unknown-linux-gnu
-        CC=aarch64-linux-gnu-gcc
+        CLANG_TARGET=aarch64-linux-gnu
     elif [ "$ARCH" = "riscv64" ]; then
         LIBPCAP_ARCH=riscv64-unknown-linux-gnu
-        CC=riscv64-linux-gnu-gcc
+        CLANG_TARGET=riscv64-linux-gnu
     else
         LIBPCAP_ARCH=x86_64-unknown-linux-gnu
-        # Use clang for native amd64 libpcap/CGO (matches BPF compilation).
-        CC=clang
+        CLANG_TARGET=x86_64-linux-gnu
     fi
 
     make clean
     echo "Building release binary for ${OS}/${ARCH}..."
-    make pwru TARGET_GOARCH=${ARCH} LIBPCAP_ARCH=${LIBPCAP_ARCH} CC=${CC} LIBPCAP_CC=${CC}
+    make pwru TARGET_GOARCH=${ARCH} LIBPCAP_ARCH=${LIBPCAP_ARCH} \
+        CC=clang LIBPCAP_CC=clang \
+        CFLAGS="--target=${CLANG_TARGET}" \
+        CGO_CFLAGS="--target=${CLANG_TARGET}" \
+        CGO_LDFLAGS="--target=${CLANG_TARGET}"
 
     test -d release/${OS}/${ARCH} || mkdir -p release/${OS}/${ARCH}
     tar -czf release/pwru-${OS}-${ARCH}.tar.gz pwru


### PR DESCRIPTION
## Summary
- Default `CC` to `clang` and define `LIBPCAP_CC ?= $(CC)` so libpcap and CGO use the same compiler as BPF builds.
- Use clang for all release arches in `local-release.sh` (`amd64`/`arm64`/`riscv64`) via `CFLAGS`/`CGO_*` `--target=` triples; gcc cross packages remain for target binutils/libc that clang links against.

Fixes #221

## Test plan
- [x] `make local-release` in the release golang container produces amd64/arm64/riscv64 artifacts with correct ELF machines
- [ ] `make clean && make` on a host with clang installed