### PR TITLE
fix: reject malformed filter-mark values

### DIFF
--- a/internal/pwru/types.go
+++ b/internal/pwru/types.go
@@ -242,6 +242,9 @@ func (f *markFlagValue) String() string {
 
 func (f *markFlagValue) Set(value string) error {
 	parts := strings.Split(value, "/")
+	if len(parts) > 2 {
+		return fmt.Errorf("invalid mark value %q: expected mark[/mask]", value)
+	}
 
 	mark, err := parseUint32HexOrDecimal(parts[0])
 	if err != nil {

--- a/internal/pwru/types_test.go
+++ b/internal/pwru/types_test.go
@@ -32,6 +32,10 @@ func TestMarkFlagValue(t *testing.T) {
 	if mark != 0xaf || mask != 0x0f {
 		t.Fatalf("Set() = mark %#x, mask %#x; want mark %#x, mask %#x", mark, mask, uint32(0xaf), uint32(0x0f))
 	}
+
+	if err := f.Set("1/2/3"); err == nil {
+		t.Fatal("Set() succeeded for a mark with too many components")
+	}
 }
 
 func TestPrintBpfmapValueStringTruncatesOversizedFields(t *testing.T) {


### PR DESCRIPTION
`--filter-mark` accepts malformed values like `1/2/3`. The third component is silently ignored, and argument parsing succeeds with mark 1 and mask 2

Reject values with more than two components. Existing `mark` and `mark/mask` forms still work

Repro:

```sh
pwru --filter-mark 1/2/3 --version
echo $?
```

Before this fix it prints the version and exits with status 0. After the fix, argument parsing fails

Tested with make test `TEST_TIMEOUT=30s` and `go vet ./....`
