### PR TITLE
fix: omit unrequested cb from JSON output

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -81,7 +81,7 @@ type jsonPrinter struct {
 	Proto       uint16     `json:"proto,omitempty"`
 	Mtu         uint32     `json:"mtu,omitempty"`
 	Len         uint32     `json:"len,omitempty"`
-	Cb          [5]uint32  `json:"cb,omitempty"`
+	Cb          *[5]uint32 `json:"cb,omitempty"`
 	Tuple       *jsonTuple `json:"tuple,omitempty"`
 	TunnelTuple *jsonTuple `json:"tunnel_tuple,omitempty"`
 	Stack       any        `json:"stack,omitempty"`
@@ -248,7 +248,7 @@ func (o *output) PrintJson(event *Event) error {
 		d.Mtu = event.Meta.MTU
 		d.Len = event.Meta.Len
 		if o.flags.FilterTraceTc || o.flags.OutputSkbCB {
-			d.Cb = event.Meta.Cb
+			d.Cb = &event.Meta.Cb
 		}
 	}
 

--- a/internal/pwru/output_test.go
+++ b/internal/pwru/output_test.go
@@ -103,6 +103,43 @@ func TestPrintJSONTupleFields(t *testing.T) {
 	}
 }
 
+func TestPrintJSONCB(t *testing.T) {
+	tests := []struct {
+		name          string
+		outputSkbCB   bool
+		filterTraceTC bool
+		wantCB        bool
+	}{
+		{name: "disabled"},
+		{name: "output skb cb", outputSkbCB: true, wantCB: true},
+		{name: "trace tc", filterTraceTC: true, wantCB: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			out := newBenchmarkOutput(&buf)
+			out.flags.OutputSkbCB = tt.outputSkbCB
+			out.flags.FilterTraceTc = tt.filterTraceTC
+
+			event := newBenchmarkEvent()
+			event.Meta.Cb = [5]uint32{1, 2, 3, 4, 5}
+			if err := out.PrintJson(event); err != nil {
+				t.Fatal(err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			_, gotCB := got["cb"]
+			if gotCB != tt.wantCB {
+				t.Fatalf("cb presence = %v, want %v: %s", gotCB, tt.wantCB, buf.String())
+			}
+		})
+	}
+}
+
 func TestSetJSONPacketData(t *testing.T) {
 	d := &jsonPrinter{}
 	flags := &Flags{OutputSkb: true, OutputShinfo: true}


### PR DESCRIPTION
`--output-json` always includes `"cb":[0,0,0,0,0]`, even when neither `--output-skb-cb` nor `--filter-trace-tc` is enabled.
Pretty noisy, and it makes the field look intentionally requested

The fix makes `cb` optional in the JSON structure. 
It remains unchanged when either supported flag enables it

Repro:

```sh
sudo ./pwru --output-json --output-limit-lines=1 'host 127.0.0.1'
```

Before this fix, every event includes cb. After the fix, it is omitted unless requested
