### PR TITLE
fix: propagate plain-text output errors

### DIFF
--- a/internal/pwru/output.go
+++ b/internal/pwru/output.go
@@ -497,7 +497,7 @@ func fprintWithPadding(writer *os.File, data string, maxLenSeen *int) {
 	fmt.Fprintf(writer, formatter, data)
 }
 
-func (o *output) Print(event *Event) {
+func (o *output) Print(event *Event) error {
 	var sb strings.Builder
 	sb.Grow(256)
 
@@ -589,7 +589,15 @@ func (o *output) Print(event *Event) {
 	}
 
 	sb.WriteString("\n")
-	o.writer.Write([]byte(sb.String()))
+	line := []byte(sb.String())
+	n, err := o.writer.Write(line)
+	if err != nil {
+		return err
+	}
+	if n != len(line) {
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 func (o *output) getIfaceName(netnsInode, ifindex uint32) string {

--- a/internal/pwru/output_test.go
+++ b/internal/pwru/output_test.go
@@ -6,10 +6,42 @@ package pwru
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"regexp"
 	"testing"
 	"time"
 )
+
+type testWriter struct {
+	n   int
+	err error
+}
+
+func (w testWriter) Write([]byte) (int, error) {
+	return w.n, w.err
+}
+
+func TestPrintError(t *testing.T) {
+	sinkErr := errors.New("sink failed")
+	tests := []struct {
+		name    string
+		writer  io.Writer
+		wantErr error
+	}{
+		{name: "writer error", writer: testWriter{err: sinkErr}, wantErr: sinkErr},
+		{name: "short write", writer: testWriter{}, wantErr: io.ErrShortWrite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := newBenchmarkOutput(tt.writer)
+			if err := out.Print(newBenchmarkEvent()); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Print() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestGetAbsoluteTs(t *testing.T) {
 	ts := getAbsoluteTs()

--- a/main.go
+++ b/main.go
@@ -405,7 +405,9 @@ func run(flags pwru.Flags) error {
 				return fmt.Errorf("Error encoding JSON: %w", err)
 			}
 		} else {
-			output.Print(&event)
+			if err := output.Print(&event); err != nil {
+				return fmt.Errorf("Error writing output: %w", err)
+			}
 		}
 
 		select {


### PR DESCRIPTION
Plain-text output ignored writer errors, so pwru could exit 0 after losing trace data

This change returns write and short-write errors to the capture loop

Repro:

```sh
sudo ./pwru --backend=kprobe --filter-func=ip_rcv \
  --output-file=/dev/full --output-limit-lines=1 'icmp' &
pid=$!
sleep 2
ping -c1 127.0.0.1
wait "$pid"
```

Before this fix the write failed but pwru exited 0. 
Now it reports ENOSPC and exits 1

Fixes: #711
