### PR TITLE
fix: prune skb-tracking programs by the flag that uses them

### DIFF
--- a/internal/pwru/skb_tracker.go
+++ b/internal/pwru/skb_tracker.go
@@ -39,22 +39,24 @@ func TrackSkb(coll *ebpf.Collection, haveFexit, trackSkbClone bool) (*skbTracker
 		t.links = append(t.links, kp)
 	}
 
-	kp, err = link.Kretprobe("veth_convert_skb_to_xdp_buff", coll.Programs["kretprobe_veth_convert_skb_to_xdp_buff"], nil)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("opening kretprobe veth_convert_skb_to_xdp_buff: %s", err)
+	if trackSkbClone {
+		kp, err = link.Kretprobe("veth_convert_skb_to_xdp_buff", coll.Programs["kretprobe_veth_convert_skb_to_xdp_buff"], nil)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("opening kretprobe veth_convert_skb_to_xdp_buff: %s", err)
+			}
+		} else {
+			t.links = append(t.links, kp)
 		}
-	} else {
-		t.links = append(t.links, kp)
-	}
 
-	kp, err = link.Kprobe("veth_convert_skb_to_xdp_buff", coll.Programs["kprobe_veth_convert_skb_to_xdp_buff"], nil)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("opening kprobe veth_convert_skb_to_xdp_buff: %s", err)
+		kp, err = link.Kprobe("veth_convert_skb_to_xdp_buff", coll.Programs["kprobe_veth_convert_skb_to_xdp_buff"], nil)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("opening kprobe veth_convert_skb_to_xdp_buff: %s", err)
+			}
+		} else {
+			t.links = append(t.links, kp)
 		}
-	} else {
-		t.links = append(t.links, kp)
 	}
 
 	if haveFexit && trackSkbClone {

--- a/main.go
+++ b/main.go
@@ -264,6 +264,9 @@ func run(flags pwru.Flags) error {
 	if !flags.FilterTrackSkb {
 		delete(bpfSpec.Programs, "kprobe_veth_convert_skb_to_xdp_buff")
 		delete(bpfSpec.Programs, "kretprobe_veth_convert_skb_to_xdp_buff")
+	}
+
+	if !flags.FilterTrackSkbByStackid {
 		delete(bpfSpec.Programs, "kprobe_skb_by_stackid")
 	}
 


### PR DESCRIPTION
issues:
```bash
# sudo pwru --filter-track-skb-by-stackid 'icmp'
2026/09/12 04:15:18 ERROR Failed to run pwru error="Failed to track skb: opening kretprobe veth_convert_skb_to_xdp_buff: prog cannot be nil: invalid input"
```
main.go pruned the veth k(ret)probes and kprobe_skb_by_stackid unless --filter-track-skb was set, while TrackSkb() opened them for either tracking flag.

Prune each program by the flag that attaches it.